### PR TITLE
Implement root detection, IEEE-style reporting, and APK evidence logging

### DIFF
--- a/device_analysis/package_scanner.py
+++ b/device_analysis/package_scanner.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import subprocess
-from typing import List, Dict
+from typing import List, Dict, Any
 
 from device_analysis.device_discovery import _adb_path, _run_adb
 
@@ -20,6 +20,17 @@ DANGEROUS_PERMISSIONS = {
     "android.permission.WRITE_EXTERNAL_STORAGE",
     "android.permission.READ_EXTERNAL_STORAGE",
     "android.permission.SYSTEM_ALERT_WINDOW",
+}
+
+# Common social media or high-value packages to flag during inventory
+HIGH_VALUE_PACKAGES = {
+    "com.twitter.android",
+    "com.instagram.android",
+    "com.facebook.katana",
+    "com.facebook.orca",
+    "com.whatsapp",
+    "com.zhiliaoapp.musically",  # TikTok
+    "com.ss.android.ugc.trill",   # TikTok alt package name
 }
 
 
@@ -67,3 +78,70 @@ def scan_for_dangerous_permissions(serial: str) -> List[Dict[str, List[str]]]:
         if risky:
             results.append({"package": pkg, "permissions": risky})
     return results
+
+
+def inventory_packages(serial: str) -> List[Dict[str, Any]]:
+    """Return detailed info for installed packages.
+
+    Each dict contains:
+        package: package name
+        path: APK path on device
+        installer: installer package name if available
+        version_name, version_code: extracted from dumpsys
+        high_value: whether package is in HIGH_VALUE_PACKAGES
+    """
+
+    adb = _adb_path()
+    try:
+        proc = _run_adb(
+            [adb, "-s", serial, "shell", "pm", "list", "packages", "-f", "-i"],
+            timeout=15,
+        )
+    except subprocess.CalledProcessError:
+        return []
+
+    packages: List[Dict[str, str]] = []
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if not line.startswith("package:"):
+            continue
+        line = line[len("package:") :]
+        installer = ""
+        if " installer=" in line:
+            pkg_part, installer = line.split(" installer=", 1)
+        else:
+            pkg_part = line
+        path = ""
+        pkg = ""
+        if "=" in pkg_part:
+            path, pkg = pkg_part.split("=", 1)
+        else:
+            pkg = pkg_part
+        info: Dict[str, str] = {
+            "package": pkg,
+            "path": path,
+            "installer": installer,
+            "version_name": "",
+            "version_code": "",
+            "high_value": pkg in HIGH_VALUE_PACKAGES,
+        }
+
+        # Fetch version details
+        try:
+            dump = _run_adb(
+                [adb, "-s", serial, "shell", "dumpsys", "package", pkg], timeout=10
+            )
+            for ln in (dump.stdout or "").splitlines():
+                ln = ln.strip()
+                if ln.startswith("versionName="):
+                    info["version_name"] = ln.split("=", 1)[1]
+                elif ln.startswith("versionCode="):
+                    info["version_code"] = ln.split("=", 1)[1].split()[0]
+                if info["version_name"] and info["version_code"]:
+                    break
+        except subprocess.CalledProcessError:
+            pass
+
+        packages.append(info)
+
+    return packages

--- a/reporting/__init__.py
+++ b/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting utilities for producing structured outputs."""

--- a/reporting/ieee_report.py
+++ b/reporting/ieee_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Utilities for rendering findings in an IEEE-style report."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from typing import Iterable, Sequence, Any, List
+
+from app_utils import app_table_display
+
+_ROMAN_MAP = [
+    (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"),
+    (100, "C"), (90, "XC"), (50, "L"), (40, "XL"),
+    (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I")
+]
+
+def _roman(num: int) -> str:
+    """Return the uppercase Roman numeral for ``num`` (1 <= num < 4000)."""
+    if num <= 0 or num >= 4000:
+        raise ValueError("number out of range for Roman numeral")
+    res = []
+    n = num
+    for val, sym in _ROMAN_MAP:
+        while n >= val:
+            res.append(sym)
+            n -= val
+    return "".join(res)
+
+def major_heading(title: str, number: int) -> str:
+    """Return an uppercase ``SECTION`` heading with a Roman numeral index."""
+    numeral = _roman(number)
+    return f"SECTION {numeral}: {title.upper()}"
+
+
+def subsection_heading(title: str, section: int, letter: str) -> str:
+    """Return a subsection heading like ``I.A – Title``."""
+    numeral = _roman(section)
+    return f"{numeral}.{letter} – {title}".strip()
+
+def _table_to_str(rows: Iterable[Sequence[Any]], headers: Sequence[str]) -> str:
+    """Render the existing ASCII table utility to a string."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        app_table_display.print_table(rows, headers=headers)
+    return buf.getvalue().rstrip()
+
+def ieee_table(title: str, headers: Sequence[str], rows: Iterable[Sequence[Any]], table_number: int) -> str:
+    """Return a table with an IEEE-style caption."""
+    caption = f"Table {_roman(table_number)}. {title}"
+    table_str = _table_to_str(rows, headers)
+    return f"{caption}\n{table_str}"
+
+def format_device_inventory(devices: List[dict[str, Any]]) -> str:
+    """Format a device inventory into a section with headings, table, and observation."""
+    heading = major_heading("Device Enumeration", 1)
+    sub = subsection_heading("Detecting Connected Devices", 1, "A")
+    intro = "The system enumerated connected Android devices and assessed trust posture."
+    rows = [
+        [d.get("serial", ""), d.get("model", ""), d.get("android_release", ""), d.get("trust", "")]
+        for d in devices
+    ]
+    table = ieee_table(
+        "Connected Devices",
+        ["Serial", "Model", "Android", "Trust"],
+        rows,
+        1,
+    )
+    obs = (
+        "Observation: The system detected {} device(s) suitable for analysis.".format(len(devices))
+        if devices
+        else "Observation: No devices were detected."
+    )
+    return f"{heading}\n{sub}\n{intro}\n\n{table}\n\n{obs}"
+
+def format_package_inventory(packages: List[dict[str, Any]]) -> str:
+    """Format application inventory with headings, table, and observation."""
+    heading = major_heading("Application Inventory", 2)
+    sub = subsection_heading("Application Discovery", 2, "A")
+    intro = (
+        "Installed packages were cataloged with version, installer source, and high-value flag."
+    )
+    rows = [
+        [
+            p.get("package", ""),
+            p.get("version_name", ""),
+            p.get("installer", ""),
+            "yes" if p.get("high_value") else "no",
+        ]
+        for p in packages
+    ]
+    table = ieee_table(
+        "Installed Applications",
+        ["Package", "Version", "Installer", "High-Value"],
+        rows,
+        2,
+    )
+    obs = (
+        "Observation: Package inventory produced {} candidate application(s) for review.".format(len(packages))
+        if packages
+        else "Observation: No packages were enumerated."
+    )
+    return f"{heading}\n{sub}\n{intro}\n\n{table}\n\n{obs}"
+
+def format_evidence_log(entries: List[dict[str, str]]) -> str:
+    """Render an evidence log appendix with headings, table, and observation."""
+    heading = major_heading("Evidence Log", 3)
+    sub = subsection_heading("Acquisition Evidence", 3, "A")
+    intro = "Chain-of-custody records for collected artifacts are listed below."
+    rows = [
+        [e.get("artifact", ""), e.get("sha256", ""), e.get("timestamp", ""), e.get("operator", "")]
+        for e in entries
+    ]
+    table = ieee_table(
+        "Acquisition Evidence",
+        ["Artifact", "SHA-256", "Timestamp", "Operator"],
+        rows,
+        3,
+    )
+    obs = (
+        "Observation: Chain-of-custody records captured for {} artifact(s).".format(len(entries))
+        if entries
+        else "Observation: No evidence entries were recorded."
+    )
+    return f"{heading}\n{sub}\n{intro}\n\n{table}\n\n{obs}"

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/testing/test_device_discovery.py
+++ b/testing/test_device_discovery.py
@@ -11,3 +11,37 @@ def test_parse_devices_l_basic():
     second = devices[1]
     assert second["serial"] == "ABCDEF123456"
     assert second["state"] == "unauthorized"
+
+
+def test_list_detailed_devices_trust(monkeypatch):
+    import device_analysis.device_discovery as dd
+
+    # Fake device list with one online device
+    monkeypatch.setattr(dd, "check_connected_devices", lambda: "ignored")
+    monkeypatch.setattr(dd, "parse_devices_l", lambda out: [{"serial": "SER", "state": "device"}])
+
+    # Provide properties indicating a developer/rooted build
+    def fake_props(serial, keys):
+        return {
+            "ro.product.manufacturer": "Acme",
+            "ro.product.model": "Model",
+            "ro.build.version.release": "11",
+            "ro.build.version.sdk": "30",
+            "ro.product.cpu.abi": "arm64-v8a",
+            "ro.board.platform": "",
+            "ro.hardware": "",
+            "ro.boot.qemu": "",
+            "ro.build.fingerprint": "acme/model:test-keys",
+            "ro.build.tags": "test-keys",
+            "ro.build.type": "userdebug",
+            "ro.debuggable": "1",
+            "ro.secure": "0",
+        }
+
+    monkeypatch.setattr(dd, "_shell_getprops", fake_props)
+
+    devices = dd.list_detailed_devices()
+    assert devices[0]["is_rooted"] is True
+    assert devices[0]["trust"] == "low"
+    assert devices[0]["debuggable"] == "1"
+    assert devices[0]["secure"] == "0"

--- a/testing/test_ieee_report.py
+++ b/testing/test_ieee_report.py
@@ -1,0 +1,54 @@
+from reporting import ieee_report
+
+
+def test_format_device_inventory_creates_section_and_table():
+    devices = [
+        {
+            "serial": "ABC123",
+            "model": "Pixel",
+            "android_release": "14",
+            "trust": "high",
+        }
+    ]
+    out = ieee_report.format_device_inventory(devices)
+    assert "SECTION I: DEVICE ENUMERATION" in out
+    assert "I.A – Detecting Connected Devices" in out
+    assert "Table I. Connected Devices" in out
+    assert "Observation:" in out
+    assert "ABC123" in out
+
+
+def test_format_package_inventory_heading_and_caption():
+    packages = [
+        {
+            "package": "com.twitter.android",
+            "version_name": "9.0",
+            "installer": "com.android.vending",
+            "high_value": True,
+        }
+    ]
+    out = ieee_report.format_package_inventory(packages)
+    assert "SECTION II: APPLICATION INVENTORY" in out
+    assert "II.A – Application Discovery" in out
+    assert "Table II. Installed Applications" in out
+    assert "Observation:" in out
+    assert "com.twitter.android" in out
+    assert "yes" in out
+
+
+def test_format_evidence_log_outputs_section_and_table():
+    entries = [
+        {
+            "artifact": "file.apk",
+            "sha256": "abc",
+            "timestamp": "2023-01-01T00:00:00Z",
+            "operator": "tester",
+        }
+    ]
+    out = ieee_report.format_evidence_log(entries)
+    assert "SECTION III: EVIDENCE LOG" in out
+    assert "III.A – Acquisition Evidence" in out
+    assert "Table III. Acquisition Evidence" in out
+    assert "Observation:" in out
+    assert "file.apk" in out
+


### PR DESCRIPTION
## Summary
- collect additional build properties and heuristics to flag rooted or developer devices
- expose trust classification and root status in device inventory
- add IEEE-style report utilities and integrate into device, package, and evidence log displays
- flag high-value social apps during package inventory and capture installer and version details
- enable APK acquisition with SHA-256 hashing and operator timestamp to maintain chain of custody
- adopt uppercase section banners, subsection markers, observation lines, and neutral status messages for runtime output
- add tests for trust assessment, report generation, package inventory, APK acquisition, and evidence logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ba98e5a08327845c40d2a4795158