### PR TITLE
refactor: modularize display and reports

### DIFF
--- a/apk_analysis/__init__.py
+++ b/apk_analysis/__init__.py
@@ -1,10 +1,29 @@
 """APK analysis helpers."""
 
-from .apk_static import analyze_apk, extract_permissions, scan_for_secrets, write_report
+from .apk_static import analyze_apk
+from .report_utils import write_report
+from .manifest_utils import (
+    extract_app_flags,
+    extract_components,
+    extract_features,
+    extract_permissions,
+    extract_permission_details,
+    extract_sdk_info,
+    extract_metadata,
+)
+from .permission_utils import categorize_permissions
+from .secret_utils import scan_for_secrets
 
 __all__ = [
     "analyze_apk",
     "extract_permissions",
+    "extract_permission_details",
+    "extract_components",
+    "extract_sdk_info",
+    "extract_features",
+    "extract_app_flags",
+    "extract_metadata",
+    "categorize_permissions",
     "scan_for_secrets",
     "write_report",
 ]

--- a/apk_analysis/manifest_utils.py
+++ b/apk_analysis/manifest_utils.py
@@ -1,0 +1,124 @@
+"""Helpers for parsing AndroidManifest.xml files."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List
+
+
+def extract_permission_details(manifest_text: str) -> List[Dict[str, Any]]:
+    """Return structured information for each ``uses-permission`` tag.
+
+    Each entry contains the permission ``name``, the originating ``tag``
+    (``uses-permission`` or ``uses-permission-sdk-23``), and any integer
+    ``max_sdk_version`` constraint.
+    """
+
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    details: List[Dict[str, Any]] = []
+    for tag in ["uses-permission", "uses-permission-sdk-23"]:
+        for elem in root.findall(tag):
+            name = elem.get(f"{{{ns['android']}}}name") or ""
+            max_sdk = elem.get(f"{{{ns['android']}}}maxSdkVersion")
+            details.append(
+                {
+                    "name": name,
+                    "tag": tag,
+                    "max_sdk_version": int(max_sdk) if max_sdk and max_sdk.isdigit() else None,
+                }
+            )
+    return details
+
+
+def extract_permissions(manifest_text: str) -> List[str]:
+    """Return unique permission strings from an AndroidManifest.xml text."""
+    return sorted({d["name"] for d in extract_permission_details(manifest_text) if d["name"]})
+
+
+def extract_components(manifest_text: str) -> Dict[str, List[Dict[str, Any]]]:
+    """Parse an AndroidManifest.xml and return exported components.
+
+    The return value maps component tag names (activity, service, receiver,
+    provider) to a list of dictionaries describing each component. Each
+    dictionary contains the component ``name``, whether it is ``exported``, and
+    any associated ``permission``.
+    """
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    result: Dict[str, List[Dict[str, Any]]] = {tag: [] for tag in ["activity", "service", "receiver", "provider"]}
+
+    app = root.find("application")
+    if app is None:
+        return result
+
+    for tag in result.keys():
+        for elem in app.findall(tag):
+            name = elem.get(f"{{{ns['android']}}}name") or ""
+            exported = elem.get(f"{{{ns['android']}}}exported")
+            permission = elem.get(f"{{{ns['android']}}}permission") or ""
+            result[tag].append(
+                {
+                    "name": name,
+                    "exported": (exported == "true") if exported is not None else False,
+                    "permission": permission,
+                }
+            )
+    return result
+
+
+def extract_sdk_info(manifest_text: str) -> Dict[str, int]:
+    """Return SDK version information from the manifest."""
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    info: Dict[str, int] = {}
+    sdk = root.find("uses-sdk")
+    if sdk is None:
+        return info
+    for attr in ["minSdkVersion", "targetSdkVersion", "maxSdkVersion"]:
+        val = sdk.get(f"{{{ns['android']}}}{attr}")
+        if val and val.isdigit():
+            info[attr] = int(val)
+    return info
+
+
+def extract_features(manifest_text: str) -> List[Dict[str, Any]]:
+    """Return a list of features requested by the app."""
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    features: List[Dict[str, Any]] = []
+    for feat in root.findall("uses-feature"):
+        name = feat.get(f"{{{ns['android']}}}name") or ""
+        required = feat.get(f"{{{ns['android']}}}required")
+        features.append({"name": name, "required": required != "false"})
+    return features
+
+
+def extract_app_flags(manifest_text: str) -> Dict[str, bool]:
+    """Return notable boolean flags from the <application> tag."""
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    app = root.find("application")
+    if app is None:
+        return {}
+    result: Dict[str, bool] = {}
+    for attr in ["debuggable", "allowBackup", "usesCleartextTraffic"]:
+        val = app.get(f"{{{ns['android']}}}{attr}")
+        if val is not None:
+            result[attr] = val == "true"
+    return result
+
+
+def extract_metadata(manifest_text: str) -> List[Dict[str, str]]:
+    """Return ``meta-data`` entries from the ``application`` tag."""
+    ns = {"android": "http://schemas.android.com/apk/res/android"}
+    root = ET.fromstring(manifest_text)
+    app = root.find("application")
+    if app is None:
+        return []
+    data: List[Dict[str, str]] = []
+    for item in app.findall("meta-data"):
+        name = item.get(f"{{{ns['android']}}}name") or ""
+        value = item.get(f"{{{ns['android']}}}value") or ""
+        data.append({"name": name, "value": value})
+    return data

--- a/apk_analysis/permission_utils.py
+++ b/apk_analysis/permission_utils.py
@@ -1,0 +1,44 @@
+"""Helpers for analyzing Android permissions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# A subset of dangerous permissions as defined by Android
+# https://developer.android.com/guide/topics/permissions/overview#dangerous_permissions
+DANGEROUS_PERMISSIONS = {
+    "android.permission.READ_CALENDAR",
+    "android.permission.WRITE_CALENDAR",
+    "android.permission.CAMERA",
+    "android.permission.READ_CONTACTS",
+    "android.permission.WRITE_CONTACTS",
+    "android.permission.GET_ACCOUNTS",
+    "android.permission.ACCESS_FINE_LOCATION",
+    "android.permission.ACCESS_COARSE_LOCATION",
+    "android.permission.RECORD_AUDIO",
+    "android.permission.READ_PHONE_STATE",
+    "android.permission.CALL_PHONE",
+    "android.permission.READ_CALL_LOG",
+    "android.permission.WRITE_CALL_LOG",
+    "com.android.voicemail.permission.ADD_VOICEMAIL",
+    "android.permission.USE_SIP",
+    "android.permission.PROCESS_OUTGOING_CALLS",
+    "android.permission.BODY_SENSORS",
+    "android.permission.SEND_SMS",
+    "android.permission.RECEIVE_SMS",
+    "android.permission.READ_SMS",
+    "android.permission.RECEIVE_WAP_PUSH",
+    "android.permission.RECEIVE_MMS",
+    "android.permission.READ_EXTERNAL_STORAGE",
+    "android.permission.WRITE_EXTERNAL_STORAGE",
+}
+
+
+def categorize_permissions(perms: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return metadata for each permission including whether it's dangerous."""
+    details: List[Dict[str, Any]] = []
+    for perm in perms:
+        entry = perm.copy()
+        entry["dangerous"] = entry.get("name") in DANGEROUS_PERMISSIONS
+        details.append(entry)
+    return details

--- a/apk_analysis/report_utils.py
+++ b/apk_analysis/report_utils.py
@@ -1,0 +1,38 @@
+"""Reporting helpers for APK static analysis."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def write_report(
+    out: Path,
+    permissions: List[str],
+    permission_details: List[Dict[str, Any]],
+    secrets: List[str],
+    components: Dict[str, List[Dict[str, Any]]],
+    sdk_info: Dict[str, int],
+    features: List[Dict[str, Any]],
+    app_flags: Dict[str, bool],
+    metadata: List[Dict[str, str]],
+) -> Path:
+    """Write a JSON report containing analysis results."""
+    report_path = out / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "permissions": permissions,
+                "permission_details": permission_details,
+                "secrets": secrets,
+                "components": components,
+                "sdk_info": sdk_info,
+                "features": features,
+                "app_flags": app_flags,
+                "metadata": metadata,
+            },
+            indent=2,
+        )
+    )
+    return report_path

--- a/apk_analysis/secret_utils.py
+++ b/apk_analysis/secret_utils.py
@@ -1,0 +1,28 @@
+"""Utility to scan source files for potential secrets."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+SECRET_PATTERN = re.compile(r"API[_-]?KEY|SECRET|TOKEN", re.IGNORECASE)
+
+
+def scan_for_secrets(root: Path) -> List[str]:
+    """Scan a directory tree for common secret keywords.
+
+    Returns a list of "path:offset" strings for each finding.
+    """
+    findings: List[str] = []
+    for file in root.rglob("*"):
+        if not file.is_file():
+            continue
+        try:
+            text = file.read_text(errors="ignore")
+        except Exception:
+            continue
+        for match in SECRET_PATTERN.finditer(text):
+            rel = file.relative_to(root)
+            findings.append(f"{rel}:{match.start()}")
+    return findings

--- a/app_utils/app_display.py
+++ b/app_utils/app_display.py
@@ -13,14 +13,13 @@ General display utilities for Android Tool.
 from __future__ import annotations
 
 import os
-import sys
 import shutil
 from textwrap import wrap
 from typing import Iterable, Sequence, Any, Optional
 
 from . import app_config
 from . import app_table_display as tables
-from .app_helpers import truncate_middle
+from .status_display import info, good, warn, fail
 
 # -----------------------------
 # Terminal / layout
@@ -79,30 +78,7 @@ def clear_screen() -> None:
     os.system("cls" if os.name == "nt" else "clear")
 
 
-# -----------------------------
-# Status lines
-# -----------------------------
-
-OK   = "[OK]"
-INF  = "[*]"
-WARN = "[!]"
-ERR  = "[X]"
-
-def _emit(prefix: str, msg: str, *, ts: bool = False, stream = sys.stdout) -> None:
-    stamp = f"{app_config.ts()} | " if ts else ""
-    print(f"{prefix} {stamp}{msg}", file=stream)
-
-def info(msg: str, *, ts: bool = False) -> None:
-    _emit(INF, msg, ts=ts, stream=sys.stdout)
-
-def good(msg: str, *, ts: bool = False) -> None:
-    _emit(OK, msg, ts=ts, stream=sys.stdout)
-
-def warn(msg: str, *, ts: bool = False) -> None:
-    _emit(WARN, msg, ts=ts, stream=sys.stderr)
-
-def fail(msg: str, *, ts: bool = False) -> None:
-    _emit(ERR, msg, ts=ts, stream=sys.stderr)
+# Status line helpers re-exported from status_display
 
 
 # -----------------------------

--- a/app_utils/app_renderers.py
+++ b/app_utils/app_renderers.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Reusable table renderers for common CLI outputs."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Any, Dict
+
+from . import app_display
+
+
+# ---------------------------------------------------------------------------
+# Device listings
+# ---------------------------------------------------------------------------
+
+def print_basic_device_table(devices: Iterable[Dict[str, Any]]) -> None:
+    """Print a simple table of connected devices."""
+    rows: List[List[str]] = [
+        [
+            d.get("serial", ""),
+            d.get("state", ""),
+            d.get("product", "-"),
+            d.get("model", "-"),
+            d.get("device", "-"),
+            d.get("transport_id", d.get("transport", "-")),
+        ]
+        for d in devices
+    ]
+    app_display.print_table(
+        rows,
+        headers=["Serial", "State", "Product", "Model", "Device", "Transport"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Package and permission reporting
+# ---------------------------------------------------------------------------
+
+def print_package_inventory(packages: Iterable[Dict[str, Any]]) -> None:
+    """Print installed package inventory."""
+    rows: List[List[str]] = [
+        [
+            p.get("package", ""),
+            p.get("version_name", ""),
+            p.get("installer", ""),
+            "yes" if p.get("high_value") else "no",
+        ]
+        for p in packages
+    ]
+    app_display.print_table(
+        rows,
+        headers=["Package", "Version", "Installer", "High-Value"],
+    )
+
+
+def print_permission_scan(results: Iterable[Dict[str, Any]]) -> None:
+    """Print packages that request dangerous permissions."""
+    rows: List[List[str]] = [
+        [r.get("package", ""), ", ".join(r.get("permissions", []))]
+        for r in results
+    ]
+    app_display.print_table(rows, headers=["Package", "Permissions"])
+
+
+# ---------------------------------------------------------------------------
+# Process listings
+# ---------------------------------------------------------------------------
+
+def print_process_table(processes: Iterable[Dict[str, Any]]) -> None:
+    """Print a table of running processes."""
+    rows: List[List[str]] = [
+        [p.get("pid", ""), p.get("user", ""), p.get("name", "")] for p in processes
+    ]
+    app_display.print_table(rows, headers=["PID", "User", "Name"])
+
+
+# ---------------------------------------------------------------------------
+# Manifest analysis renderers
+# ---------------------------------------------------------------------------
+
+def print_feature_list(features: Iterable[Dict[str, Any]]) -> None:
+    """Print requested hardware/software features."""
+    rows: List[List[str]] = [
+        [f.get("name", ""), "yes" if f.get("required") else "no"]
+        for f in features
+    ]
+    app_display.print_table(rows, headers=["Feature", "Required"])
+
+
+def print_component_table(
+    components: Dict[str, List[Dict[str, Any]]], kind: str
+) -> None:
+    """Print details for a specific component kind (activity/service/etc)."""
+    rows: List[List[str]] = [
+        [c.get("name", ""), "yes" if c.get("exported") else "no", c.get("permission", "")]
+        for c in components.get(kind, [])
+    ]
+    app_display.print_table(
+        rows,
+        headers=["Name", "Exported", "Permission"],
+    )

--- a/app_utils/status_display.py
+++ b/app_utils/status_display.py
@@ -1,0 +1,39 @@
+"""Status line utilities for terminal output."""
+
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+OK = "[OK]"
+INF = "[*]"
+WARN = "[!]"
+ERR = "[X]"
+
+
+def _emit(prefix: str, msg: str, *, ts: bool = False, stream: TextIO = sys.stdout) -> None:
+    """Internal helper to print a prefixed message."""
+    from . import app_config
+
+    stamp = f"{app_config.ts()} | " if ts else ""
+    print(f"{prefix} {stamp}{msg}", file=stream)
+
+
+def info(msg: str, *, ts: bool = False) -> None:
+    """Print an informational status line."""
+    _emit(INF, msg, ts=ts, stream=sys.stdout)
+
+
+def good(msg: str, *, ts: bool = False) -> None:
+    """Print a success status line."""
+    _emit(OK, msg, ts=ts, stream=sys.stdout)
+
+
+def warn(msg: str, *, ts: bool = False) -> None:
+    """Print a warning status line."""
+    _emit(WARN, msg, ts=ts, stream=sys.stderr)
+
+
+def fail(msg: str, *, ts: bool = False) -> None:
+    """Print an error status line."""
+    _emit(ERR, msg, ts=ts, stream=sys.stderr)

--- a/device_analysis/__init__.py
+++ b/device_analysis/__init__.py
@@ -2,3 +2,4 @@ from . import apk_extractor
 from .apk_extractor import pull_apk
 
 __all__ = ["apk_extractor", "pull_apk"]
+

--- a/device_analysis/adb_utils.py
+++ b/device_analysis/adb_utils.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Shared helpers for invoking ``adb`` commands."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from app_utils import app_config
+
+
+def _run_adb(args: list[str], *, timeout: int = 8) -> subprocess.CompletedProcess:
+    """Run adb with robust defaults and return the completed process."""
+    return subprocess.run(args, capture_output=True, text=True, check=True, timeout=timeout)
+
+
+def _adb_path() -> str:
+    """Return the best ``adb`` path available on this system."""
+    path = app_config.get_adb_path()
+    which = shutil.which("adb")
+    try:
+        subprocess.run(
+            [path, "version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        return path
+    except Exception:
+        return which or path

--- a/device_analysis/apk_extractor.py
+++ b/device_analysis/apk_extractor.py
@@ -9,7 +9,7 @@ import getpass
 from datetime import datetime
 from typing import Dict
 
-from .device_discovery import _adb_path, _run_adb
+from .adb_utils import _adb_path, _run_adb
 
 
 def pull_apk(serial: str, package: str, dest_dir: str = "output/apks") -> Path:

--- a/device_analysis/device_discovery.py
+++ b/device_analysis/device_discovery.py
@@ -1,38 +1,21 @@
 #!/usr/bin/env python3
 # device_analysis/device_discovery.py
-"""
-Helpers for discovering and enriching connected Android devices via ADB.
-"""
+"""Helpers for discovering and enriching connected Android devices via ADB."""
 
 from __future__ import annotations
-import shutil
+
 import subprocess
-from typing import List, Dict, Any
-from app_utils import app_config
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List
 
-
-# -----------------------------
-# Low-level ADB runners
-# -----------------------------
-
-def _run_adb(args: list[str], *, timeout: int = 8) -> subprocess.CompletedProcess:
-    """
-    Run adb with robust defaults. Raises FileNotFoundError, CalledProcessError, PermissionError as-is.
-    """
-    return subprocess.run(args, capture_output=True, text=True, check=True, timeout=timeout)
-
-
-def _adb_path() -> str:
-    # Prefer executable SDK adb, else PATH adb, else the SDK candidate
-    path = app_config.get_adb_path()
-    which = shutil.which("adb")
-    # If our chosen path is not executable but PATH has one, prefer PATH
-    try:
-        # quick, non-raising probe
-        subprocess.run([path, "version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2)
-        return path
-    except Exception:
-        return which or path
+from .adb_utils import _adb_path, _run_adb
+from .device_props import (
+    get_props,
+    _infer_connection_kind,
+    _infer_is_emulator,
+    _infer_root_status,
+    _short_fingerprint,
+)
 
 
 # -----------------------------
@@ -40,10 +23,7 @@ def _adb_path() -> str:
 # -----------------------------
 
 def check_connected_devices() -> str:
-    """
-    Run `adb devices -l` and return the raw stdout.
-    Raises RuntimeError with a friendly message on failure.
-    """
+    """Run `adb devices -l` and return the raw stdout."""
     adb = _adb_path()
     try:
         result = _run_adb([adb, "devices", "-l"])
@@ -67,15 +47,10 @@ def check_connected_devices() -> str:
 # -----------------------------
 
 def parse_devices_l(output: str) -> List[Dict[str, str]]:
-    """
-    Parse `adb devices -l` into a list of dicts with keys:
-      serial, state, product, model, device, transport_id, usb, (any other key:value tokens present)
-    """
+    """Parse `adb devices -l` into a list of dicts."""
     lines = [ln.strip() for ln in (output or "").splitlines() if ln.strip()]
     if not lines:
         return []
-
-    # Drop header if present
     if lines[0].lower().startswith("list of devices"):
         lines = lines[1:]
 
@@ -96,149 +71,31 @@ def parse_devices_l(output: str) -> List[Dict[str, str]]:
 
 
 # -----------------------------
-# Enrichment helpers
-# -----------------------------
-
-_PROP_KEYS = [
-    "ro.product.manufacturer",
-    "ro.product.model",
-    "ro.build.version.release",
-    "ro.build.version.sdk",
-    "ro.product.cpu.abi",
-    "ro.board.platform",
-    "ro.hardware",
-    "ro.boot.qemu",
-    "ro.build.fingerprint",
-    # Properties useful for basic trust / rooting heuristics
-    "ro.build.tags",
-    "ro.build.type",
-    "ro.debuggable",
-    "ro.secure",
-]
-
-def _shell_getprops(serial: str, keys: list[str]) -> Dict[str, str]:
-    """
-    Fetch multiple getprop keys in one shell call (faster than N calls).
-    Returns a dict {key: value}. Missing keys -> ''.
-    """
-    adb = _adb_path()
-    # Build a single command that echoes key=value lines
-    lines = []
-    for k in keys:
-        # Quote the key and produce "key=value" lines
-        lines.append(f'echo "{k}=$(getprop {k})"')
-    cmd = " ; ".join(lines)
-    try:
-        proc = _run_adb([adb, "-s", serial, "shell", cmd], timeout=6)
-        out = proc.stdout or ""
-    except Exception:
-        return {k: "" for k in keys}
-
-    result: Dict[str, str] = {k: "" for k in keys}
-    for ln in out.splitlines():
-        if "=" in ln:
-            k, v = ln.split("=", 1)
-            k = k.strip()
-            v = v.strip()
-            if k in result:
-                result[k] = v
-    return result
-
-
-def _infer_connection_kind(serial: str, meta: Dict[str, str]) -> str:
-    """
-    Try to infer whether connection is USB or TCP/IP.
-    - presence of meta['usb'] usually means USB (e.g., 'usb:1-13')
-    - serial like '192.168.1.5:5555' implies TCP/IP
-    """
-    if "usb" in meta:
-        return "USB"
-    if ":" in serial and all(ch.isdigit() or ch == "." for ch in serial.split(":")[0]):
-        return "TCPIP"
-    return "UNKNOWN"
-
-
-def _infer_is_emulator(serial: str, props: Dict[str, str], meta: Dict[str, str]) -> bool:
-    """
-    Heuristics to detect emulator:
-    - serial starts with 'emulator-'
-    - ro.boot.qemu == '1'
-    - manufacturer strings commonly used by emulators (best-effort)
-    """
-    if serial.startswith("emulator-"):
-        return True
-    if props.get("ro.boot.qemu") == "1":
-        return True
-    manuf = (props.get("ro.product.manufacturer") or "").lower()
-    if manuf in {"genymotion", "unknown", "goldfish", "google"}:
-        # goldfish/ranchu are AOSP emulator hw
-        fp = (props.get("ro.build.fingerprint") or "").lower()
-        if "generic" in fp or "ranchu" in fp or "goldfish" in fp:
-            return True
-    # If it lacks USB info and looks like TCP/IP + generic fingerprint, treat as emulator
-    if _infer_connection_kind(serial, meta) == "TCPIP":
-        fp = (props.get("ro.build.fingerprint") or "").lower()
-        if "generic" in fp or "sdk" in fp:
-            return True
-    return False
-
-
-def _infer_root_status(props: Dict[str, str]) -> bool:
-    """Best-effort check for signs of a rooted or developer build."""
-    # ro.secure=0 indicates a non-secure build
-    if props.get("ro.secure") == "0":
-        return True
-    # ro.debuggable=1 allows adb shell with root-like capabilities
-    if props.get("ro.debuggable") == "1":
-        return True
-    # test-keys in build tags often means an engineering build
-    tags = (props.get("ro.build.tags") or "").lower()
-    if "test-keys" in tags:
-        return True
-    # eng/userdebug builds are typically non-production
-    build_type = props.get("ro.build.type", "")
-    if build_type in {"eng", "userdebug"}:
-        return True
-    return False
-
-
-def _short_fingerprint(fp: str, maxlen: int = 48) -> str:
-    if not fp:
-        return ""
-    if len(fp) <= maxlen:
-        return fp
-    return fp[:maxlen - 1] + "…"
-
-
-# -----------------------------
 # Public: list detailed devices
 # -----------------------------
 
 def list_detailed_devices() -> List[Dict[str, Any]]:
-    """
-    Returns a list of enriched device dicts for display/selection.
-    Each item has:
-      - serial, state
-      - connection: USB|TCPIP|UNKNOWN
-      - type: physical|emulator|unknown
-      - manufacturer, model
-      - android_release, sdk
-      - abi, platform, hardware
-      - product, device (from -l)
-      - fingerprint_short
-      - build_tags, build_type, debuggable, secure
-      - is_rooted and a simple trust classification
-    """
+    """Return a list of enriched device dicts for display/selection."""
     raw = check_connected_devices()
     base = parse_devices_l(raw)
 
-    detailed: List[Dict[str, str]] = []
+    serials = [d["serial"] for d in base if d.get("state", "").lower() == "device"]
+    props_map: Dict[str, Dict[str, str]] = {}
+    if serials:
+        def _fetch(serial: str) -> tuple[str, Dict[str, str]]:
+            return serial, get_props(serial)
+
+        with ThreadPoolExecutor(max_workers=min(8, len(serials))) as ex:
+            for serial, props in ex.map(_fetch, serials):
+                props_map[serial] = props
+
+    detailed: List[Dict[str, Any]] = []
     for d in base:
         serial = d.get("serial", "")
         state = (d.get("state") or "").lower()
+        props = props_map.get(serial, {})
 
-        # Default augmented fields
-        info: Dict[str, str] = {
+        info: Dict[str, Any] = {
             "serial": serial,
             "state": state,
             "connection": _infer_connection_kind(serial, d),
@@ -262,28 +119,25 @@ def list_detailed_devices() -> List[Dict[str, Any]]:
             "fingerprint_short": "",
         }
 
-        # Only query props when the device is fully online
         if state == "device":
-            props = _shell_getprops(serial, _PROP_KEYS)
-            info["manufacturer"]   = props.get("ro.product.manufacturer", "")
-            info["model"]          = props.get("ro.product.model", "")
-            info["android_release"]= props.get("ro.build.version.release", "")
-            info["sdk"]            = props.get("ro.build.version.sdk", "")
-            info["abi"]            = props.get("ro.product.cpu.abi", "")
-            info["platform"]       = props.get("ro.board.platform", "")
-            info["hardware"]       = props.get("ro.hardware", "")
-            info["build_tags"]     = props.get("ro.build.tags", "")
-            info["build_type"]     = props.get("ro.build.type", "")
-            info["debuggable"]     = props.get("ro.debuggable", "")
-            info["secure"]         = props.get("ro.secure", "")
-            fp                     = props.get("ro.build.fingerprint", "")
+            info["manufacturer"] = props.get("ro.product.manufacturer", "")
+            info["model"] = props.get("ro.product.model", "")
+            info["android_release"] = props.get("ro.build.version.release", "")
+            info["sdk"] = props.get("ro.build.version.sdk", "")
+            info["abi"] = props.get("ro.product.cpu.abi", "")
+            info["platform"] = props.get("ro.board.platform", "")
+            info["hardware"] = props.get("ro.hardware", "")
+            info["build_tags"] = props.get("ro.build.tags", "")
+            info["build_type"] = props.get("ro.build.type", "")
+            info["debuggable"] = props.get("ro.debuggable", "")
+            info["secure"] = props.get("ro.secure", "")
+            fp = props.get("ro.build.fingerprint", "")
             info["fingerprint_short"] = _short_fingerprint(fp)
             info["type"] = "emulator" if _infer_is_emulator(serial, props, d) else "physical"
             rooted = _infer_root_status(props)
             info["is_rooted"] = rooted
             info["trust"] = "low" if rooted else "high"
         else:
-            # unauthorized / offline / recovery / sideload etc. → skip props
             info["type"] = "unknown"
 
         detailed.append(info)

--- a/device_analysis/device_props.py
+++ b/device_analysis/device_props.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Helpers for retrieving and interpreting device properties."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .adb_utils import _adb_path, _run_adb
+
+
+_PROP_KEYS = [
+    "ro.product.manufacturer",
+    "ro.product.model",
+    "ro.build.version.release",
+    "ro.build.version.sdk",
+    "ro.product.cpu.abi",
+    "ro.board.platform",
+    "ro.hardware",
+    "ro.boot.qemu",
+    "ro.build.fingerprint",
+    "ro.build.tags",
+    "ro.build.type",
+    "ro.debuggable",
+    "ro.secure",
+]
+
+
+def _shell_getprops(serial: str, keys: list[str]) -> Dict[str, str]:
+    """Fetch multiple getprop keys in one shell call and return a mapping."""
+    adb = _adb_path()
+    lines = [f'echo "{k}=$(getprop {k})"' for k in keys]
+    cmd = " ; ".join(lines)
+    try:
+        proc = _run_adb([adb, "-s", serial, "shell", cmd], timeout=6)
+        out = proc.stdout or ""
+    except Exception:
+        return {k: "" for k in keys}
+
+    result: Dict[str, str] = {k: "" for k in keys}
+    for ln in out.splitlines():
+        if "=" in ln:
+            k, v = ln.split("=", 1)
+            k = k.strip()
+            v = v.strip()
+            if k in result:
+                result[k] = v
+    return result
+
+
+@lru_cache(maxsize=32)
+def _cached_props(serial: str) -> Dict[str, str]:
+    """Return cached property map for a device serial."""
+    return _shell_getprops(serial, _PROP_KEYS)
+
+
+def get_props(serial: str, keys: list[str] | None = None) -> Dict[str, str]:
+    """Return cached properties for the given serial."""
+    props = _cached_props(serial)
+    if not keys or keys is _PROP_KEYS:
+        return props
+    return {k: props.get(k, "") for k in keys}
+
+
+def _infer_connection_kind(serial: str, meta: Dict[str, str]) -> str:
+    """Best-effort guess of USB vs TCPIP connection."""
+    if "usb" in meta:
+        return "USB"
+    if ":" in serial and all(ch.isdigit() or ch == "." for ch in serial.split(":")[0]):
+        return "TCPIP"
+    return "UNKNOWN"
+
+
+def _infer_is_emulator(serial: str, props: Dict[str, str], meta: Dict[str, str]) -> bool:
+    """Return True if heuristics indicate the device is an emulator."""
+    if serial.startswith("emulator-"):
+        return True
+    if props.get("ro.boot.qemu") == "1":
+        return True
+    manuf = (props.get("ro.product.manufacturer") or "").lower()
+    if manuf in {"genymotion", "unknown", "goldfish", "google"}:
+        fp = (props.get("ro.build.fingerprint") or "").lower()
+        if "generic" in fp or "ranchu" in fp or "goldfish" in fp:
+            return True
+    if _infer_connection_kind(serial, meta) == "TCPIP":
+        fp = (props.get("ro.build.fingerprint") or "").lower()
+        if "generic" in fp or "sdk" in fp:
+            return True
+    return False
+
+
+def _infer_root_status(props: Dict[str, str]) -> bool:
+    """Best-effort check for signs of a rooted or developer build."""
+    if props.get("ro.secure") == "0":
+        return True
+    if props.get("ro.debuggable") == "1":
+        return True
+    tags = (props.get("ro.build.tags") or "").lower()
+    if "test-keys" in tags:
+        return True
+    build_type = props.get("ro.build.type", "")
+    if build_type in {"eng", "userdebug"}:
+        return True
+    return False
+
+
+def _short_fingerprint(fp: str, maxlen: int = 48) -> str:
+    if not fp:
+        return ""
+    if len(fp) <= maxlen:
+        return fp
+    return fp[: maxlen - 1] + "…"

--- a/device_analysis/package_scanner.py
+++ b/device_analysis/package_scanner.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import subprocess
 from typing import List, Dict, Any
 
-from device_analysis.device_discovery import _adb_path, _run_adb
+from .adb_utils import _adb_path, _run_adb
 
 # A small, non-exhaustive set of permissions considered risky for demos.
 DANGEROUS_PERMISSIONS = {

--- a/device_analysis/process_listing.py
+++ b/device_analysis/process_listing.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import subprocess
 from typing import List, Dict
 
-from device_analysis.device_discovery import _adb_path, _run_adb
+from .adb_utils import _adb_path, _run_adb
 
 
 def parse_ps(output: str) -> List[Dict[str, str]]:

--- a/testing/test_apk_analysis.py
+++ b/testing/test_apk_analysis.py
@@ -1,11 +1,22 @@
 from pathlib import Path
 
-from apk_analysis import extract_permissions, scan_for_secrets, write_report
+from apk_analysis import (
+    extract_permissions,
+    extract_permission_details,
+    extract_components,
+    extract_sdk_info,
+    extract_features,
+    extract_app_flags,
+    extract_metadata,
+    categorize_permissions,
+    scan_for_secrets,
+    write_report,
+)
 
 
 def test_extract_permissions():
     manifest = (
-        '<manifest>'
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
         '<uses-permission android:name="android.permission.INTERNET"/>'
         '<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>'
         '</manifest>'
@@ -17,6 +28,32 @@ def test_extract_permissions():
     ]
 
 
+def test_extract_permission_details():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<uses-permission android:name="android.permission.CAMERA" android:maxSdkVersion="28"/>'
+        '<uses-permission-sdk-23 android:name="android.permission.READ_CONTACTS"/>'
+        '</manifest>'
+    )
+    details = extract_permission_details(manifest)
+    assert {
+        "name": "android.permission.CAMERA",
+        "tag": "uses-permission",
+        "max_sdk_version": 28,
+    } in details
+    assert any(d["tag"] == "uses-permission-sdk-23" and d["name"] == "android.permission.READ_CONTACTS" for d in details)
+
+
+def test_categorize_permissions():
+    perms = [
+        {"name": "android.permission.INTERNET", "tag": "uses-permission", "max_sdk_version": None},
+        {"name": "android.permission.READ_CONTACTS", "tag": "uses-permission", "max_sdk_version": None},
+    ]
+    details = categorize_permissions(perms)
+    assert any(d["name"] == "android.permission.READ_CONTACTS" and d["dangerous"] for d in details)
+    assert any(d["name"] == "android.permission.INTERNET" and not d["dangerous"] for d in details)
+
+
 def test_scan_for_secrets(tmp_path: Path):
     sample = tmp_path / "Sample.java"
     sample.write_text("String API_KEY = \"abc\";")
@@ -24,8 +61,94 @@ def test_scan_for_secrets(tmp_path: Path):
     assert results and "Sample.java" in results[0]
 
 
+def test_extract_components():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<application>'
+        '<activity android:name="MainActivity" android:exported="true" />'
+        '<service android:name="MyService" android:permission="com.example.PERMISSION" />'
+        '</application>'
+        '</manifest>'
+    )
+    comps = extract_components(manifest)
+    assert comps["activity"][0]["name"] == "MainActivity"
+    assert comps["activity"][0]["exported"] is True
+    assert comps["service"][0]["permission"] == "com.example.PERMISSION"
+
+
+def test_extract_sdk_info():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />'
+        '</manifest>'
+    )
+    info = extract_sdk_info(manifest)
+    assert info["minSdkVersion"] == 21
+    assert info["targetSdkVersion"] == 30
+
+
+def test_extract_features():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<uses-feature android:name="android.hardware.camera" android:required="false" />'
+        '</manifest>'
+    )
+    features = extract_features(manifest)
+    assert features[0]["name"] == "android.hardware.camera"
+    assert features[0]["required"] is False
+
+
+def test_extract_app_flags():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<application android:debuggable="true" android:allowBackup="false" android:usesCleartextTraffic="true" />'
+        '</manifest>'
+    )
+    flags = extract_app_flags(manifest)
+    assert flags["debuggable"] is True
+    assert flags["allowBackup"] is False
+    assert flags["usesCleartextTraffic"] is True
+
+
+def test_extract_metadata():
+    manifest = (
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+        '<application>'
+        '<meta-data android:name="com.example.API_KEY" android:value="123" />'
+        '</application>'
+        '</manifest>'
+    )
+    data = extract_metadata(manifest)
+    assert data == [{"name": "com.example.API_KEY", "value": "123"}]
+
+
 def test_write_report(tmp_path: Path):
-    report = write_report(tmp_path, ["android.permission.INTERNET"], ["Sample.java:10"])
+    comps = {"activity": [{"name": "Main", "exported": False, "permission": ""}]}
+    perm_details = [
+        {
+            "name": "android.permission.INTERNET",
+            "tag": "uses-permission",
+            "max_sdk_version": None,
+            "dangerous": False,
+        }
+    ]
+    metadata = [{"name": "com.example.API_KEY", "value": "123"}]
+    report = write_report(
+        tmp_path,
+        ["android.permission.INTERNET"],
+        perm_details,
+        ["Sample.java:10"],
+        comps,
+        {"minSdkVersion": 21},
+        [{"name": "android.hardware.camera", "required": False}],
+        {"debuggable": True},
+        metadata,
+    )
     data = report.read_text()
     assert "android.permission.INTERNET" in data
     assert "Sample.java:10" in data
+    assert "Main" in data
+    assert "minSdkVersion" in data
+    assert "android.hardware.camera" in data
+    assert "debuggable" in data
+    assert "com.example.API_KEY" in data

--- a/testing/test_app_renderers.py
+++ b/testing/test_app_renderers.py
@@ -1,0 +1,17 @@
+from app_utils import app_renderers
+
+
+def test_feature_list_renderer(capsys):
+    feats = [{"name": "camera", "required": True}]
+    app_renderers.print_feature_list(feats)
+    out = capsys.readouterr().out
+    assert "camera" in out
+    assert "yes" in out
+
+
+def test_component_table_renderer(capsys):
+    comps = {"activity": [{"name": "MainActivity", "exported": True, "permission": ""}]}
+    app_renderers.print_component_table(comps, "activity")
+    out = capsys.readouterr().out
+    assert "MainActivity" in out
+    assert "yes" in out

--- a/testing/test_device_discovery.py
+++ b/testing/test_device_discovery.py
@@ -1,6 +1,5 @@
 from device_analysis.device_discovery import parse_devices_l
 
-
 def test_parse_devices_l_basic():
     output = """List of devices attached\nemulator-5554\tdevice product:sdk_gphone_x86 model:sdk_gphone_x86 device:emulator_x86 transport_id:1\nABCDEF123456\tunauthorized\n"""
     devices = parse_devices_l(output)
@@ -21,7 +20,7 @@ def test_list_detailed_devices_trust(monkeypatch):
     monkeypatch.setattr(dd, "parse_devices_l", lambda out: [{"serial": "SER", "state": "device"}])
 
     # Provide properties indicating a developer/rooted build
-    def fake_props(serial, keys):
+    def fake_props(serial):
         return {
             "ro.product.manufacturer": "Acme",
             "ro.product.model": "Model",
@@ -38,7 +37,7 @@ def test_list_detailed_devices_trust(monkeypatch):
             "ro.secure": "0",
         }
 
-    monkeypatch.setattr(dd, "_shell_getprops", fake_props)
+    monkeypatch.setattr(dd, "get_props", fake_props)
 
     devices = dd.list_detailed_devices()
     assert devices[0]["is_rooted"] is True

--- a/testing/test_status_display.py
+++ b/testing/test_status_display.py
@@ -1,0 +1,14 @@
+from app_utils import status_display
+
+
+def test_status_lines(capsys):
+    status_display.info("hello")
+    status_display.good("there")
+    status_display.warn("warn")
+    status_display.fail("fail")
+
+    out = capsys.readouterr()
+    assert "[OK]" in out.out
+    assert "[*]" in out.out
+    assert "[!]" in out.err
+    assert "[X]" in out.err


### PR DESCRIPTION
## Summary
- extract status line helpers into a dedicated module and slim down app display utilities
- move report generation to an isolated helper and add CLI renderers for manifest features and components
- surface manifest insights after APK analysis and add tests for new display helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c0f0546c83279d3b5419f45015b1