### PR TITLE
Handle missing APK tools gracefully

### DIFF
--- a/apk_analysis/apk_static.py
+++ b/apk_analysis/apk_static.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Sequence
 
+from app_utils import app_display
 from .manifest_utils import (
     extract_app_flags,
     extract_components,
@@ -21,6 +22,18 @@ from .secret_utils import scan_for_secrets
 from .report_utils import calculate_derived_metrics, write_report
 
 
+def _run_tool(cmd: Sequence[str], tool_name: str) -> None:
+    """Execute an external tool and surface friendly errors."""
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)
+    except FileNotFoundError:
+        app_display.fail(f"{tool_name} is not installed or not found in PATH")
+        raise RuntimeError(f"{tool_name} missing") from None
+    except subprocess.CalledProcessError as e:
+        app_display.fail(f"{tool_name} failed: {e}")
+        raise RuntimeError(f"{tool_name} execution failed") from e
+
+
 def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
     """Decompile an APK and run simple static analysis.
 
@@ -32,20 +45,9 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
     apktool_dir = out / "apktool"
     jadx_dir = out / "jadx"
 
-    subprocess.run([
-        "apktool",
-        "d",
-        str(apk),
-        "-o",
-        str(apktool_dir),
-    ], check=True, stdout=subprocess.DEVNULL)
+    _run_tool(["apktool", "d", str(apk), "-o", str(apktool_dir)], "apktool")
 
-    subprocess.run([
-        "jadx",
-        "-d",
-        str(jadx_dir),
-        str(apk),
-    ], check=True, stdout=subprocess.DEVNULL)
+    _run_tool(["jadx", "-d", str(jadx_dir), str(apk)], "jadx")
 
     manifest = apktool_dir / "AndroidManifest.xml"
     perms: List[str] = []


### PR DESCRIPTION
## Summary
- Gracefully handle missing `apktool` or `jadx` by catching `FileNotFoundError` and `CalledProcessError`
- Emit user-friendly failure messages and raise `RuntimeError` to abort analysis
- Centralize tool invocation into a helper to reduce duplication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ceda11e883278f0a26c64333e617