### PR TITLE
Add permission monitor for appops via adb

### DIFF
--- a/sandbox/permission_monitor.py
+++ b/sandbox/permission_monitor.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Utility to monitor Android runtime permission accesses via ``adb``.
+
+This module hooks into ``adb shell dumpsys appops`` (or ``appops`` directly)
+output to watch for runtime permission checks while an application is
+running. Each permission access is logged with a timestamp and the calling
+component. A summary of the observed accesses can be retrieved for report
+generation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import DefaultDict, Dict, Iterable, List
+
+from device_analysis import adb_utils
+
+logger = logging.getLogger(__name__)
+
+
+def _run_shell(cmd: list[str]) -> str:
+    """Run ``adb shell`` with *cmd* and return stdout as text."""
+    adb_path = adb_utils._adb_path()
+    proc = adb_utils._run_adb([adb_path, "shell", *cmd])
+    return proc.stdout
+
+
+class PermissionMonitor:
+    """Monitor permission accesses for a device or specific package."""
+
+    def __init__(self, package: str | None = None, *, use_dumpsys: bool = True):
+        self.package = package
+        self.use_dumpsys = use_dumpsys
+        self._summary: DefaultDict[str, int] = defaultdict(int)
+        self._logs: List[PermissionAccess] = []
+
+    def poll(self) -> None:
+        """Poll ``appops`` and update internal summary and logs."""
+        if self.use_dumpsys:
+            cmd = ["dumpsys", "appops"]
+        else:
+            cmd = ["appops", "get"]
+            if self.package:
+                cmd.append(self.package)
+        output = _run_shell(cmd)
+        self._parse_output(output)
+
+    def _parse_output(self, output: str) -> None:
+        pattern = re.compile(
+            r"Op\s+(?P<perm>[A-Z_\.]+).*?from uid\s+\d+\s+pkg\s+(?P<comp>[\w\.]+)"
+        )
+        for line in output.splitlines():
+            line = line.strip()
+            match = pattern.search(line)
+            if not match:
+                continue
+            perm = match.group("perm")
+            comp = match.group("comp")
+            timestamp = datetime.now(tz=timezone.utc).isoformat()
+            access = PermissionAccess(timestamp, perm, comp)
+            logger.info("%s | %s accessed by %s", timestamp, perm, comp)
+            self._summary[perm] += 1
+            self._logs.append(access)
+
+    def get_summary(self) -> Dict[str, int]:
+        """Return a ``{permission: count}`` summary of logged accesses."""
+        return dict(self._summary)
+
+    def get_logs(self) -> Iterable["PermissionAccess"]:
+        """Return an iterable of logged permission accesses."""
+        return list(self._logs)
+
+    def clear(self) -> None:
+        """Clear stored logs and summary counts."""
+        self._summary.clear()
+        self._logs.clear()
+
+
+@dataclass
+class PermissionAccess:
+    """Structured record describing a single permission access."""
+
+    timestamp: str
+    permission: str
+    component: str
+
+
+__all__ = ["PermissionMonitor", "PermissionAccess"]

--- a/testing/test_permission_monitor.py
+++ b/testing/test_permission_monitor.py
@@ -1,0 +1,23 @@
+from sandbox import permission_monitor
+from sandbox.permission_monitor import PermissionMonitor
+
+
+def test_permission_monitor_summary(monkeypatch):
+    sample_output = (
+        "Op ACCESS_FINE_LOCATION from uid 1000 pkg com.example\n"
+        "Op READ_SMS from uid 1001 pkg com.sms.app"
+    )
+    monkeypatch.setattr(permission_monitor, "_run_shell", lambda cmd: sample_output)
+    monitor = PermissionMonitor()
+    monitor.poll()
+    assert monitor.get_summary() == {
+        "ACCESS_FINE_LOCATION": 1,
+        "READ_SMS": 1,
+    }
+    logs = list(monitor.get_logs())
+    assert len(logs) == 2
+    assert logs[0].permission == "ACCESS_FINE_LOCATION"
+    assert logs[0].component == "com.example"
+    monitor.clear()
+    assert monitor.get_summary() == {}
+    assert list(monitor.get_logs()) == []


### PR DESCRIPTION
## Summary
- Add sandbox permission monitor that parses `adb shell dumpsys appops` output
- Log each permission access with timestamps and calling component
- Provide summary API returning `{permission: count}` for reports
- Store structured permission access logs and expose retrieval/clear APIs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3cfd57770832794966dd6239a39c7