### PR TITLE
Add risk scoring model and reporting integration

### DIFF
--- a/analysis_scoring/__init__.py
+++ b/analysis_scoring/__init__.py
@@ -1,0 +1,5 @@
+"""Risk scoring utilities for analysis pipelines."""
+
+from .risk_score import calculate_risk_score, DEFAULT_WEIGHTS, DEFAULT_CAPS
+
+__all__ = ["calculate_risk_score", "DEFAULT_WEIGHTS", "DEFAULT_CAPS"]

--- a/analysis_scoring/risk_score.py
+++ b/analysis_scoring/risk_score.py
@@ -1,0 +1,121 @@
+"""Weighted risk scoring model for static and dynamic analysis metrics.
+
+The scoring model uses a configurable set of metric weights.  By default the
+weights are tuned for a handful of high‑signal static and dynamic indicators but
+callers may override them to experiment with alternate models.  Count‑based
+metrics are normalised to the range ``[0, 1]`` using per‑metric caps so that
+weights are applied consistently regardless of the raw scale of each metric.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# Default weights for metrics.  These will be normalised to sum to ``1.0``
+# inside :func:`calculate_risk_score` so callers can provide partial overrides
+# without worrying about the sum of the values.
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "permission_density": 0.3,
+    "component_exposure": 0.2,
+    "permission_invocation_count": 0.2,
+    "cleartext_endpoint_count": 0.2,
+    "file_write_count": 0.1,
+}
+
+# Normalisation caps for count based metrics.  The selected caps are heuristic
+# and merely prevent extremely large counts from dominating the score.
+DEFAULT_CAPS: Dict[str, float] = {
+    "permission_invocation_count": 50,
+    "cleartext_endpoint_count": 10,
+    "file_write_count": 100,
+}
+
+
+def _normalize_count(value: float, cap: float) -> float:
+    """Normalize ``value`` to ``[0, 1]`` using ``cap`` as an upper bound."""
+    if cap <= 0:
+        return 0.0
+    return min(value / cap, 1.0)
+
+
+def calculate_risk_score(
+    static_metrics: Dict[str, float] | None = None,
+    dynamic_metrics: Dict[str, float] | None = None,
+    *,
+    weights: Dict[str, float] | None = None,
+    caps: Dict[str, float] | None = None,
+) -> Dict[str, Any]:
+    """Return a risk score and rationale based on analysis metrics.
+
+    Parameters
+    ----------
+    static_metrics:
+        Metrics derived from static analysis such as ``permission_density``
+        and ``component_exposure``.
+    dynamic_metrics:
+        Metrics from dynamic analysis such as permission invocation counts,
+        cleartext network endpoints, or file system writes.
+    weights:
+        Optional weighting overrides.  Values are normalised so the final
+        weights sum to ``1.0``.
+    caps:
+        Optional overrides for the normalisation caps of count based metrics.
+
+    Returns
+    -------
+    dict
+        ``{"score": float, "rationale": str, "breakdown": dict}``
+    """
+
+    static_metrics = static_metrics or {}
+    dynamic_metrics = dynamic_metrics or {}
+
+    # Merge weights/caps with defaults and normalise weights to sum to 1.0.
+    weights = {**DEFAULT_WEIGHTS, **(weights or {})}
+    total_weight = sum(weights.values()) or 1.0
+    weights = {k: v / total_weight for k, v in weights.items()}
+    caps = {**DEFAULT_CAPS, **(caps or {})}
+
+    # Merge metrics for easier lookup.
+    all_metrics: Dict[str, float] = {**static_metrics, **dynamic_metrics}
+
+    score = 0.0
+    breakdown: Dict[str, float] = {}
+    for metric, weight in weights.items():
+        value = float(all_metrics.get(metric, 0.0))
+        if metric in caps:
+            value = _normalize_count(value, caps[metric])
+        score += value * weight
+        breakdown[metric] = round(value * weight * 100, 2)
+
+    # Generate human readable rationale using heuristic thresholds for the
+    # default metrics.  These can be expanded as additional metrics are added.
+    pd = float(static_metrics.get("permission_density", 0.0))
+    ce = float(static_metrics.get("component_exposure", 0.0))
+    perm_inv = float(dynamic_metrics.get("permission_invocation_count", 0.0))
+    cleartext = float(dynamic_metrics.get("cleartext_endpoint_count", 0.0))
+    file_writes = float(dynamic_metrics.get("file_write_count", 0.0))
+
+    rationale_parts: list[str] = []
+    if pd > 0.5:
+        rationale_parts.append("elevated permission density")
+    if ce > 0.5:
+        rationale_parts.append("many exported components")
+    if perm_inv > 10:
+        rationale_parts.append("frequent permission use")
+    if cleartext > 0:
+        rationale_parts.append("cleartext network endpoints detected")
+    if file_writes > 0:
+        rationale_parts.append("file system writes observed")
+
+    rationale = (
+        "; ".join(rationale_parts)
+        if rationale_parts
+        else "no significant risk factors observed"
+    )
+
+    return {
+        "score": round(score * 100, 2),
+        "rationale": rationale,
+        "breakdown": breakdown,
+    }

--- a/apk_analysis/apk_static.py
+++ b/apk_analysis/apk_static.py
@@ -19,6 +19,7 @@ from .manifest_utils import (
 from .permission_utils import categorize_permissions
 from .secret_utils import scan_for_secrets
 from .report_utils import calculate_derived_metrics, write_report
+from analysis_scoring import calculate_risk_score
 
 
 def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
@@ -83,6 +84,11 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
     )
     (out / "derived_metrics.json").write_text(json.dumps(metrics, indent=2))
 
+    # Placeholder for dynamic metrics; future instrumentation can populate these
+    dynamic_metrics: Dict[str, float] = {}
+    risk = calculate_risk_score(metrics, dynamic_metrics)
+    (out / "risk_score.json").write_text(json.dumps(risk, indent=2))
+
     write_report(
         out,
         perms,
@@ -94,6 +100,7 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
         app_flags,
         metadata,
         metrics,
+        risk,
     )
 
     return out

--- a/apk_analysis/report_utils.py
+++ b/apk_analysis/report_utils.py
@@ -87,6 +87,7 @@ def write_report(
     app_flags: Dict[str, bool],
     metadata: List[Dict[str, str]],
     metrics: Dict[str, float] | None = None,
+    risk: Dict[str, Any] | None = None,
 ) -> Path:
     """Write a JSON report containing analysis results."""
     report_path = out / "report.json"
@@ -102,6 +103,7 @@ def write_report(
                 "app_flags": app_flags,
                 "metadata": metadata,
                 "metrics": metrics or {},
+                "risk": risk or {},
             },
             indent=2,
         )

--- a/reporting/ieee_report.py
+++ b/reporting/ieee_report.py
@@ -123,3 +123,16 @@ def format_evidence_log(entries: List[dict[str, str]]) -> str:
         else "Observation: No evidence entries were recorded."
     )
     return f"{heading}\n{sub}\n{intro}\n\n{table}\n\n{obs}"
+
+
+def format_risk_summary(risk: dict[str, Any]) -> str:
+    """Render a risk assessment section."""
+    heading = major_heading("Risk Assessment", 4)
+    sub = subsection_heading("Aggregated Risk Score", 4, "A")
+    score = risk.get("score", 0.0)
+    rationale = risk.get("rationale", "")
+    breakdown_items = risk.get("breakdown", {})
+    rows = [(k.replace("_", " "), f"{v:.2f}") for k, v in breakdown_items.items()]
+    table = ieee_table("Risk Breakdown", ["Metric", "Contribution"], rows, 4)
+    obs = f"Observation: Overall risk score is {score:.2f}."
+    return f"{heading}\n{sub}\n{rationale}\n\n{table}\n\n{obs}"

--- a/testing/test_apk_analysis.py
+++ b/testing/test_apk_analysis.py
@@ -13,6 +13,7 @@ from apk_analysis import (
     write_report,
     calculate_derived_metrics,
 )
+from analysis_scoring import calculate_risk_score
 
 
 def test_extract_permissions():
@@ -141,6 +142,7 @@ def test_write_report(tmp_path: Path):
         [{"name": "android.hardware.camera", "required": False}],
         metadata,
     )
+    risk = calculate_risk_score(metrics, {})
     report = write_report(
         tmp_path,
         ["android.permission.INTERNET"],
@@ -152,6 +154,7 @@ def test_write_report(tmp_path: Path):
         {"debuggable": True},
         metadata,
         metrics,
+        risk,
     )
     data = report.read_text()
     assert "android.permission.INTERNET" in data
@@ -163,6 +166,8 @@ def test_write_report(tmp_path: Path):
     assert "com.example.API_KEY" in data
     assert "permission_density" in data
     assert "feature_count" in data
+    assert "risk" in data
+    assert "rationale" in data
 
 
 def test_calculate_derived_metrics():

--- a/testing/test_ieee_report.py
+++ b/testing/test_ieee_report.py
@@ -52,3 +52,17 @@ def test_format_evidence_log_outputs_section_and_table():
     assert "Observation:" in out
     assert "file.apk" in out
 
+
+def test_format_risk_summary_includes_score_and_breakdown():
+    risk = {
+        "score": 42.5,
+        "rationale": "Example rationale",
+        "breakdown": {"permission_density": 12.3},
+    }
+    out = ieee_report.format_risk_summary(risk)
+    assert "SECTION IV: RISK ASSESSMENT" in out
+    assert "IV.A – Aggregated Risk Score" in out
+    assert "Table IV. Risk Breakdown" in out
+    assert "42.5" in out
+    assert "Example rationale" in out
+

--- a/testing/test_risk_score.py
+++ b/testing/test_risk_score.py
@@ -1,0 +1,23 @@
+from analysis_scoring import calculate_risk_score
+
+
+def test_calculate_risk_score_outputs_score_and_rationale():
+    static = {"permission_density": 0.6, "component_exposure": 0.4}
+    dynamic = {
+        "permission_invocation_count": 20,
+        "cleartext_endpoint_count": 1,
+        "file_write_count": 5,
+    }
+    result = calculate_risk_score(static, dynamic)
+    assert 0 <= result["score"] <= 100
+    assert isinstance(result["rationale"], str)
+    assert result["rationale"]
+    assert "breakdown" in result and "permission_density" in result["breakdown"]
+
+
+def test_weights_can_be_overridden():
+    static = {"permission_density": 0.8, "component_exposure": 0.0}
+    default = calculate_risk_score(static)
+    # Heavily emphasise permission density
+    override = calculate_risk_score(static, weights={"permission_density": 10.0})
+    assert override["score"] > default["score"]


### PR DESCRIPTION
## Summary
- Implement weighted risk scoring that fuses static permission metrics and dynamic runtime indicators to produce a score, rationale, and breakdown
- Calculate and embed risk assessment in APK analysis reports and expose a text formatter for final reports
- Allow configurable metric weights and normalisation caps so downstream tooling can tune the model
- Cover new functionality with unit tests for scoring and report rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3cfd49ab88327b8775cb987484d25