### PR TITLE
handle single device selection

### DIFF
--- a/devices/selection.py
+++ b/devices/selection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # selection.py
 """
-Allows users to list connected devices and select one to connect to, 
+Allows users to list connected devices and select one to connect to,
 with numbered selection for easier navigation.
 """
 
@@ -13,14 +13,35 @@ def list_and_select_device() -> str:
     """Display connected devices and return the chosen serial."""
     try:
         devices = discovery.list_detailed_devices()
+        connected = [d for d in devices if d.get("state") == "device"]
 
-        if not devices:
+        if not connected:
             display.warn("No devices attached.")
             return ""
 
+        if len(connected) == 1:
+            selected = connected[0]
+            dtype = selected.get("type", "unknown")
+            display.good(f"Selected {dtype} device: {selected['serial']}")
+
+            display.print_section("Device Details")
+            display.print_kv(
+                [
+                    ("Serial", selected.get("serial", "")),
+                    ("Model", selected.get("model", "")),
+                    ("Manufacturer", selected.get("manufacturer", "")),
+                    ("Android", selected.get("android_release", "")),
+                    ("SDK", selected.get("sdk", "")),
+                    ("Connection", selected.get("connection", "")),
+                    ("Type", dtype),
+                ]
+            )
+
+            return selected.get("serial", "")
+
         labels = [
-            f"{d.get('serial')} | {d.get('model') or '-'} | {d.get('state')}"
-            for d in devices
+            f"{d.get('serial')} | {d.get('model') or '-'} | {d.get('type', '')}"
+            for d in connected
         ]
 
         choice = menu.show_menu(
@@ -34,7 +55,8 @@ def list_and_select_device() -> str:
             display.warn("No device selected.")
             return ""
 
-        selected = devices[choice - 1]
+        selected = connected[choice - 1]
+        dtype = selected.get("type", "unknown")
         display.good(f"Selected device: {selected['serial']}")
 
         display.print_section("Device Details")
@@ -46,7 +68,7 @@ def list_and_select_device() -> str:
                 ("Android", selected.get("android_release", "")),
                 ("SDK", selected.get("sdk", "")),
                 ("Connection", selected.get("connection", "")),
-                ("Type", selected.get("type", "")),
+                ("Type", dtype),
             ]
         )
 


### PR DESCRIPTION
## Summary
- check for at least one connected device before displaying menu
- when exactly one device is connected, show its type and details without menu
- include device type in multi-device menu options

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e30dc99c8327b379cdd51ded4fde