### PR TITLE
feat(cli): improve APK path prompts

### DIFF
--- a/cli/actions.py
+++ b/cli/actions.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 from core import display, menu, renderers, config
+from .prompts import prompt_existing_path
 from reports import ieee
 from devices import (
     discovery,
@@ -97,10 +98,13 @@ def list_running_processes(serial: str) -> None:
 
 def analyze_apk_path() -> None:
     """Prompt for an APK path and run the static analyzer."""
-    apk_path = input("Enter path to APK: ").strip()
+    apk_path = prompt_existing_path(
+        "Enter path to APK (or press Enter to cancel): ",
+        "Status: APK analysis canceled.",
+    )
     if not apk_path:
-        print("Status: APK path is required.")
         return
+
     try:
         out = analyze_apk(apk_path)
     except Exception as e:  # pragma: no cover - broad catch for user feedback
@@ -154,9 +158,11 @@ def analyze_installed_app(serial: str) -> None:
 
 def sandbox_analyze_apk() -> None:
     """Prompt for an APK path and run sandbox analysis."""
-    apk_path = input("Enter path to APK: ").strip()
+    apk_path = prompt_existing_path(
+        "Enter path to APK (or press Enter to cancel): ",
+        "Status: Sandbox analysis canceled.",
+    )
     if not apk_path:
-        print("Status: APK path is required.")
         return
 
     outdir = config.OUTPUT_DIR / f"{Path(apk_path).stem}_sandbox"

--- a/cli/prompts.py
+++ b/cli/prompts.py
@@ -1,0 +1,23 @@
+"""Reusable CLI prompt helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def prompt_existing_path(prompt: str, cancel_message: str) -> Optional[str]:
+    """Prompt user for a filesystem path until an existing path is provided.
+
+    If the user presses Enter without input, prints ``cancel_message`` and
+    returns ``None``.
+    """
+    while True:
+        path_str = input(prompt).strip()
+        if not path_str:
+            print(cancel_message)
+            return None
+        if Path(path_str).exists():
+            return path_str
+        print("Status: Provided path does not exist.")
+


### PR DESCRIPTION
## Summary
- require valid APK path for static analyzer
- require valid APK path for sandbox analyzer
- extract reusable APK path prompt helper

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a3e30e9ac48327aa7f58cab99da136