### PR TITLE
Add job scheduler and CLI utilities

### DIFF
--- a/cli/jobs.py
+++ b/cli/jobs.py
@@ -1,0 +1,77 @@
+"""Command-line helpers for job queue interaction."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from analysis import analyze_apk
+from orchestrator import scheduler, start_worker
+
+
+def submit(apk: str) -> str:
+    """Submit an APK for analysis and return the job ID."""
+    path = Path(apk)
+    if not path.exists():
+        raise FileNotFoundError(f"{apk} does not exist")
+    job_id = scheduler.submit_job(analyze_apk, str(path))
+    print(f"Job submitted: {job_id}")
+    return job_id
+
+
+def status(job_id: Optional[str] = None) -> None:
+    """Print the status of a single job or all jobs."""
+    if job_id:
+        print(f"{job_id}: {scheduler.job_status(job_id)}")
+        return
+    for jid, stat in scheduler.list_jobs().items():
+        print(f"{jid}: {stat}")
+
+
+def result(job_id: str) -> None:
+    """Print the stored result or error for ``job_id``."""
+    job = scheduler.get_job(job_id)
+    if not job:
+        print(f"{job_id}: unknown")
+        return
+    if job.status == "completed":
+        print(job.result)
+    elif job.status == "failed":
+        print(job.error)
+    else:
+        print(f"{job_id}: {job.status}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for job queue commands."""
+    parser = argparse.ArgumentParser(description="Job queue utilities")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_submit = sub.add_parser("submit", help="submit APK for analysis")
+    p_submit.add_argument("apk")
+
+    p_status = sub.add_parser("status", help="show job status")
+    p_status.add_argument("job_id", nargs="?", default=None)
+
+    p_result = sub.add_parser("result", help="show job result or error")
+    p_result.add_argument("job_id")
+
+    sub.add_parser("worker", help="start a worker and process jobs")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "submit":
+        submit(args.apk)
+    elif args.cmd == "status":
+        status(args.job_id)
+    elif args.cmd == "result":
+        result(args.job_id)
+    elif args.cmd == "worker":
+        # Start worker in foreground and wait for queue to empty
+        start_worker(daemon=False)
+        scheduler.wait_for_all()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,5 @@
+"""Simple orchestration utilities for analysis jobs."""
+from .scheduler import scheduler
+from .worker import start_worker
+
+__all__ = ["scheduler", "start_worker"]

--- a/orchestrator/scheduler.py
+++ b/orchestrator/scheduler.py
@@ -1,0 +1,95 @@
+"""In-memory job scheduler using a queue."""
+from __future__ import annotations
+
+import queue
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class Job:
+    """Represents a unit of work to be processed."""
+
+    id: str
+    func: Callable[..., Any]
+    args: tuple[Any, ...] = field(default_factory=tuple)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    status: str = "queued"
+    result: Any | None = None
+    error: str | None = None
+
+
+class Scheduler:
+    """Basic scheduler backed by :class:`queue.Queue`."""
+
+    def __init__(self) -> None:
+        self._queue: queue.Queue[Job] = queue.Queue()
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+
+    def submit_job(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
+        """Queue a new job and return its identifier."""
+        job_id = uuid.uuid4().hex
+        job = Job(job_id, func, args, kwargs)
+        with self._lock:
+            self._jobs[job_id] = job
+        self._queue.put(job)
+        return job_id
+
+    def get_next_job(self, timeout: float | None = None) -> Job:
+        """Return the next job from the queue, blocking if necessary."""
+        return self._queue.get(timeout=timeout)
+
+    def mark_running(self, job: Job) -> None:
+        """Mark a job as running."""
+        with self._lock:
+            job.status = "running"
+
+    def mark_done(self, job: Job, result: Any) -> None:
+        """Record successful completion of a job."""
+        with self._lock:
+            job.status = "completed"
+            job.result = result
+        self._queue.task_done()
+
+    def mark_failed(self, job: Job, exc: Exception) -> None:
+        """Record a job failure."""
+        with self._lock:
+            job.status = "failed"
+            job.error = str(exc)
+        self._queue.task_done()
+
+    def job_status(self, job_id: str) -> str:
+        """Return the status for ``job_id``."""
+        with self._lock:
+            job = self._jobs.get(job_id)
+            return job.status if job else "unknown"
+
+    def get_job(self, job_id: str) -> Job | None:
+        """Return the :class:`Job` instance for ``job_id`` if known."""
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def job_result(self, job_id: str) -> Any | None:
+        """Return the result stored for ``job_id`` if completed."""
+        job = self.get_job(job_id)
+        return job.result if job else None
+
+    def job_error(self, job_id: str) -> str | None:
+        """Return the error message for ``job_id`` if it failed."""
+        job = self.get_job(job_id)
+        return job.error if job else None
+
+    def list_jobs(self) -> dict[str, str]:
+        """Return mapping of job IDs to their statuses."""
+        with self._lock:
+            return {job_id: job.status for job_id, job in self._jobs.items()}
+
+    def wait_for_all(self) -> None:
+        """Block until all queued jobs are processed."""
+        self._queue.join()
+
+
+scheduler = Scheduler()

--- a/orchestrator/worker.py
+++ b/orchestrator/worker.py
@@ -1,0 +1,27 @@
+"""Worker routines for processing queued jobs."""
+from __future__ import annotations
+
+from typing import Any
+
+from .scheduler import scheduler, Job
+
+
+def worker_loop() -> None:
+    """Continuously pull jobs from the scheduler and execute them."""
+    while True:
+        job: Job = scheduler.get_next_job()
+        try:
+            scheduler.mark_running(job)
+            result = job.func(*job.args, **job.kwargs)
+            scheduler.mark_done(job, result)
+        except Exception as exc:  # pragma: no cover - simple error capture
+            scheduler.mark_failed(job, exc)
+
+
+def start_worker(daemon: bool = True) -> None:
+    """Start a background thread running :func:`worker_loop`."""
+    import threading
+
+    thread = threading.Thread(target=worker_loop, daemon=daemon)
+    thread.start()
+    return thread

--- a/testing/test_job_queue.py
+++ b/testing/test_job_queue.py
@@ -1,0 +1,30 @@
+from orchestrator.scheduler import Scheduler
+import orchestrator.scheduler as scheduler_module
+import orchestrator.worker as worker_module
+import cli.jobs as jobs
+
+
+def _reset_scheduler():
+    sched = Scheduler()
+    scheduler_module.scheduler = sched
+    worker_module.scheduler = sched
+    jobs.scheduler = sched
+    return sched
+
+
+def test_job_lifecycle(tmp_path, monkeypatch, capsys):
+    sched = _reset_scheduler()
+    monkeypatch.setattr(jobs, "analyze_apk", lambda path: "ok")
+
+    apk = tmp_path / "dummy.apk"
+    apk.write_text("data")
+
+    job_id = jobs.submit(str(apk))
+    worker_module.start_worker(daemon=True)
+    sched.wait_for_all()
+
+    jobs.status(job_id)
+    assert "completed" in capsys.readouterr().out
+
+    jobs.result(job_id)
+    assert capsys.readouterr().out.strip() == "ok"


### PR DESCRIPTION
## Summary
- introduce in-memory job scheduler with queue-backed worker
- add worker loop to execute analysis jobs
- expose CLI commands for submitting jobs, checking status, and retrieving results
- add tests for job lifecycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6f4eca48327ae1c1831d6e6c287