### PR TITLE
Remove duplicate permission collection stub

### DIFF
--- a/sandbox/permission_monitor.py
+++ b/sandbox/permission_monitor.py
@@ -22,15 +22,6 @@ from devices import adb
 logger = logging.getLogger(__name__)
 
 
-def collect_permissions(apk_path: str) -> List[str]:
-    """Stub collecting of runtime permissions for *apk_path*.
-
-    This simplified implementation returns a fixed permission list suitable
-    for tests without requiring an attached device.
-    """
-    return ["android.permission.INTERNET"]
-
-
 def _run_shell(cmd: list[str]) -> str:
     """Run ``adb shell`` with *cmd* and return stdout as text."""
     adb_path = adb._adb_path()

--- a/testing/test_permission_monitor.py
+++ b/testing/test_permission_monitor.py
@@ -1,3 +1,5 @@
+import inspect
+
 from sandbox import permission_monitor
 from sandbox.permission_monitor import PermissionMonitor
 
@@ -21,3 +23,8 @@ def test_permission_monitor_summary(monkeypatch):
     monitor.clear()
     assert monitor.get_summary() == {}
     assert list(monitor.get_logs()) == []
+
+
+def test_single_collect_permissions_definition():
+    src = inspect.getsource(permission_monitor)
+    assert src.count("def collect_permissions") == 1


### PR DESCRIPTION
## Summary
- remove redundant stub collect_permissions implementation
- add test ensuring permission_monitor only defines collect_permissions once

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e81b5b648327b3dd4b7724c52347