### PR TITLE
Add local threat intel scoring for network flows

### DIFF
--- a/risk_scoring/risk_score.py
+++ b/risk_scoring/risk_score.py
@@ -20,6 +20,7 @@ DEFAULT_WEIGHTS: Dict[str, float] = {
     "permission_invocation_count": 0.2,
     "cleartext_endpoint_count": 0.2,
     "file_write_count": 0.1,
+    "malicious_endpoint_count": 0.1,
 }
 
 # Normalisation caps for count based metrics.  The selected caps are heuristic
@@ -28,6 +29,7 @@ DEFAULT_CAPS: Dict[str, float] = {
     "permission_invocation_count": 50,
     "cleartext_endpoint_count": 10,
     "file_write_count": 100,
+    "malicious_endpoint_count": 10,
 }
 
 
@@ -95,6 +97,7 @@ def calculate_risk_score(
     perm_inv = float(dynamic_metrics.get("permission_invocation_count", 0.0))
     cleartext = float(dynamic_metrics.get("cleartext_endpoint_count", 0.0))
     file_writes = float(dynamic_metrics.get("file_write_count", 0.0))
+    malicious = float(dynamic_metrics.get("malicious_endpoint_count", 0.0))
 
     rationale_parts: list[str] = []
     if pd > 0.5:
@@ -107,6 +110,8 @@ def calculate_risk_score(
         rationale_parts.append("cleartext network endpoints detected")
     if file_writes > 0:
         rationale_parts.append("file system writes observed")
+    if malicious > 0:
+        rationale_parts.append("connections to known malicious endpoints")
 
     rationale = (
         "; ".join(rationale_parts)

--- a/sandbox/intel.py
+++ b/sandbox/intel.py
@@ -1,0 +1,61 @@
+"""Simple local threat intelligence lookup utilities.
+
+This module loads IP and domain reputation data from plain text feeds such as
+Maltrail or AbuseIPDB exports.  Each line of a feed file is expected to contain
+an IP address or domain name.  Lines beginning with ``#`` are treated as
+comments and ignored.
+
+The reputation model is intentionally minimal: any entry found in the feeds is
+assigned a score of ``100`` while unknown entries return ``0``.  The lightweight
+interface keeps the module easy to test and sufficient for basic risk scoring
+purposes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+# In-memory sets of known-bad indicators populated via :func:`load_feeds`.
+BAD_IPS: set[str] = set()
+BAD_DOMAINS: set[str] = set()
+
+
+def load_feeds(paths: Iterable[str | Path]) -> None:
+    """Populate :data:`BAD_IPS` and :data:`BAD_DOMAINS` from ``paths``.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of file paths containing newline separated IPs or domains.
+    """
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if any(c.isalpha() for c in line):
+                BAD_DOMAINS.add(line.lower())
+            else:
+                BAD_IPS.add(line)
+
+
+def score_ip(ip: str) -> int:
+    """Return a simple reputation score for ``ip``.
+
+    The score is ``100`` if the IP appears in the loaded feeds, otherwise ``0``.
+    """
+    return 100 if ip in BAD_IPS else 0
+
+
+def score_domain(domain: str) -> int:
+    """Return a reputation score for ``domain``.
+
+    The score is ``100`` if the domain appears in the loaded feeds, otherwise
+    ``0``.
+    """
+    return 100 if domain.lower() in BAD_DOMAINS else 0
+

--- a/testing/test_network.py
+++ b/testing/test_network.py
@@ -6,13 +6,19 @@ import pytest
 
 
 @pytest.mark.skipif(
-    __import__('importlib').util.find_spec('scapy') is None,
+    __import__("importlib").util.find_spec("scapy") is None,
     reason="scapy is not available",
 )
 def test_parse_pcap_tracks_ip_flows(tmp_path: Path) -> None:
     """``parse_pcap`` should record IP flow information for packets."""
     from scapy.all import IP, TCP, Raw, wrpcap  # type: ignore
+    from sandbox import intel
     from sandbox.network import parse_pcap
+
+    # Load a simple reputation feed with a known bad IP and domain
+    feed = tmp_path / "feed.txt"
+    feed.write_text("93.184.216.34\nexample.com\n")
+    intel.load_feeds([feed])
 
     pkt = (
         IP(src="10.1.1.1", dst="93.184.216.34")
@@ -27,10 +33,18 @@ def test_parse_pcap_tracks_ip_flows(tmp_path: Path) -> None:
     assert summary["unencrypted_http_request_count"] == 1
     assert summary["ip_flow_count"] == 1
     flow = summary["ip_flows"][0]
-    assert flow == {"src": "10.1.1.1", "dst": "93.184.216.34", "count": 1}
+    assert flow["src"] == "10.1.1.1" and flow["dst"] == "93.184.216.34"
+    assert flow["src_rep"] == 0 and flow["dst_rep"] == 100
     assert set(summary["unique_ips"]) == {"10.1.1.1", "93.184.216.34"}
     req = summary["unencrypted_http_requests"][0]
     assert req["src_ip"] == "10.1.1.1"
     assert req["dst_ip"] == "93.184.216.34"
+    assert req["reputation"] == 100
     assert summary["unexpected_domains"] == ["example.com"]
+    assert summary["malicious_ip_count"] == 1
+    assert summary["malicious_domain_count"] == 1
+
+    # Reset global intel state for other tests
+    intel.BAD_IPS.clear()
+    intel.BAD_DOMAINS.clear()
 

--- a/testing/test_risk_score.py
+++ b/testing/test_risk_score.py
@@ -7,12 +7,15 @@ def test_calculate_risk_score_outputs_score_and_rationale():
         "permission_invocation_count": 20,
         "cleartext_endpoint_count": 1,
         "file_write_count": 5,
+        "malicious_endpoint_count": 2,
     }
     result = calculate_risk_score(static, dynamic)
     assert 0 <= result["score"] <= 100
     assert isinstance(result["rationale"], str)
     assert result["rationale"]
     assert "breakdown" in result and "permission_density" in result["breakdown"]
+    assert "malicious_endpoint_count" in result["breakdown"]
+    assert "malicious" in result["rationale"]
 
 
 def test_weights_can_be_overridden():


### PR DESCRIPTION
## Summary
- add sandbox.intel to load IP/domain reputation feeds
- tag network flows with reputation and aggregate malicious endpoint metrics
- include malicious endpoint count in risk scoring model and rationale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e81ab4b083278340360a77330364