### PR TITLE
Add APK signature verification and trust scoring

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -13,6 +13,7 @@ from .manifest import (
 )
 from .permissions import categorize_permissions
 from .secrets import scan_for_secrets
+from .signature import verify_signature
 
 __all__ = [
     "analyze_apk",
@@ -25,6 +26,7 @@ __all__ = [
     "extract_metadata",
     "categorize_permissions",
     "scan_for_secrets",
+    "verify_signature",
     "write_report",
     "calculate_derived_metrics",
 ]

--- a/analysis/signature.py
+++ b/analysis/signature.py
@@ -1,0 +1,112 @@
+"""APK signature validation utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from apksigtool import (
+    APKSignatureSchemeBlock,
+    VerificationError,
+    extract_v2_sig,
+    parse_apk_signing_block,
+    verify_apk_signature_scheme_v2,
+    verify_apk_signature_scheme_v3,
+)
+
+# Path to the default trust store containing trusted certificate fingerprints.
+TRUST_STORE_PATH = Path(__file__).with_name("trust_store.json")
+
+
+def _load_trusted_fingerprints(path: Path | None = None) -> List[str]:
+    """Load trusted certificate fingerprints from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a JSON file containing a list under the key
+        ``"trusted_fingerprints"``.  If the file is missing or malformed an
+        empty list is returned.
+    """
+
+    path = path or TRUST_STORE_PATH
+    try:
+        data = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    fingerprints = data.get("trusted_fingerprints", [])
+    # Normalise to uppercase hexadecimal strings for comparison.
+    return [fp.upper() for fp in fingerprints if isinstance(fp, str)]
+
+
+def verify_signature(
+    apk_path: str | Path,
+    *,
+    trust_store: str | Path | None = None,
+) -> Dict[str, object]:
+    """Validate the APK's signature and compare against a trust store.
+
+    Parameters
+    ----------
+    apk_path:
+        Path to the APK file to inspect.
+    trust_store:
+        Optional path to an alternate trust store.  Defaults to
+        ``analysis/trust_store.json``.
+
+    Returns
+    -------
+    dict
+        ``{"valid": bool, "trusted": bool, "fingerprints": list[str]}``
+
+    The ``valid`` field indicates if the APK's v2/v3 signature verified
+    successfully. ``trusted`` will be ``True`` when any certificate fingerprint
+    matches an entry in the trust store.
+    """
+
+    apk_path = Path(apk_path)
+    fingerprints: List[str] = []
+    valid = False
+
+    try:
+        # ``extract_v2_sig`` returns the offset of the signing block and the raw
+        # data for further parsing.  This covers both APK Signature Scheme v2 and
+        # v3 as they share the same container format.
+        _, sig_block = extract_v2_sig(str(apk_path))
+        for pair in parse_apk_signing_block(sig_block).pairs:
+            block = pair.value
+            if not isinstance(block, APKSignatureSchemeBlock):
+                continue
+            try:
+                if block.is_v2():
+                    verify_apk_signature_scheme_v2(block.signers, str(apk_path))
+                else:
+                    verify_apk_signature_scheme_v3(block.signers, str(apk_path))
+            except VerificationError:
+                valid = False
+                break
+            else:
+                valid = True
+                for signer in block.signers:
+                    for cert in signer.signed_data.certificates:
+                        try:
+                            cert_obj = x509.load_der_x509_certificate(cert.data)
+                            fp = cert_obj.fingerprint(hashes.SHA256()).hex().upper()
+                            fingerprints.append(fp)
+                        except Exception:
+                            continue
+    except Exception:
+        valid = False
+
+    trusted_fps = _load_trusted_fingerprints(
+        Path(trust_store) if trust_store else TRUST_STORE_PATH
+    )
+    trusted = any(fp in trusted_fps for fp in fingerprints)
+
+    return {"valid": valid, "trusted": trusted, "fingerprints": fingerprints}
+
+
+__all__ = ["verify_signature", "TRUST_STORE_PATH"]

--- a/analysis/static.py
+++ b/analysis/static.py
@@ -20,6 +20,7 @@ from .manifest import (
 from .permissions import categorize_permissions
 from .secrets import scan_for_secrets
 from .report import calculate_derived_metrics, write_report
+from .signature import verify_signature
 from risk_scoring import calculate_risk_score
 
 
@@ -84,6 +85,8 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
     metrics = calculate_derived_metrics(
         perm_details, components, sdk_info, features, metadata
     )
+    sig_info = verify_signature(apk_path)
+    metrics["untrusted_signature"] = 0 if sig_info.get("trusted") else 1
     (out / "derived_metrics.json").write_text(json.dumps(metrics, indent=2))
 
     # Placeholder for dynamic metrics; future instrumentation can populate these

--- a/analysis/trust_store.json
+++ b/analysis/trust_store.json
@@ -1,0 +1,3 @@
+{
+  "trusted_fingerprints": []
+}

--- a/risk_scoring/risk_score.py
+++ b/risk_scoring/risk_score.py
@@ -20,6 +20,11 @@ DEFAULT_WEIGHTS: Dict[str, float] = {
     "permission_invocation_count": 0.2,
     "cleartext_endpoint_count": 0.2,
     "file_write_count": 0.1,
+    # Presence of an untrusted or missing signature is a strong indicator that
+    # the APK may have been tampered with.  This is represented as a binary
+    # metric in the range ``[0, 1]`` where ``1`` denotes an untrusted
+    # signature.
+    "untrusted_signature": 0.1,
 }
 
 # Normalisation caps for count based metrics.  The selected caps are heuristic
@@ -95,6 +100,7 @@ def calculate_risk_score(
     perm_inv = float(dynamic_metrics.get("permission_invocation_count", 0.0))
     cleartext = float(dynamic_metrics.get("cleartext_endpoint_count", 0.0))
     file_writes = float(dynamic_metrics.get("file_write_count", 0.0))
+    untrusted_sig = float(static_metrics.get("untrusted_signature", 0.0))
 
     rationale_parts: list[str] = []
     if pd > 0.5:
@@ -107,6 +113,8 @@ def calculate_risk_score(
         rationale_parts.append("cleartext network endpoints detected")
     if file_writes > 0:
         rationale_parts.append("file system writes observed")
+    if untrusted_sig > 0:
+        rationale_parts.append("signature could not be trusted")
 
     rationale = (
         "; ".join(rationale_parts)


### PR DESCRIPTION
## Summary
- add `analysis.signature` module to extract certificate fingerprints and verify against a trusted store
- incorporate signature validation into static analysis metrics
- extend risk scoring to weigh untrusted signatures and report rationale
- switch signature validation to the `apksigtool` library for proper APK Signature Scheme v2/v3 verification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6f4ae1c832791fcdf7ef2700a26