### PR TITLE
Add manifest and secret scanning tests with CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 .mypy_cache/
 .pytest_cache/
 output/
+.coverage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov=. --cov-report=term-missing
+testpaths = testing

--- a/testing/test_manifest.py
+++ b/testing/test_manifest.py
@@ -1,0 +1,96 @@
+from analysis.manifest import (
+    extract_permission_details,
+    extract_permissions,
+    extract_components,
+    extract_sdk_info,
+    extract_features,
+    extract_app_flags,
+    extract_metadata,
+)
+
+MANIFEST = """<?xml version='1.0'?>
+<manifest xmlns:android='http://schemas.android.com/apk/res/android'>
+    <uses-permission android:name='android.permission.INTERNET'/>
+    <uses-permission-sdk-23 android:name='android.permission.CAMERA' android:maxSdkVersion='28'/>
+    <uses-sdk android:minSdkVersion='21' android:targetSdkVersion='33'/>
+    <uses-feature android:name='feature1' android:required='true'/>
+    <uses-feature android:name='feature2' android:required='false'/>
+    <application android:debuggable='true' android:allowBackup='false' android:usesCleartextTraffic='true'>
+        <activity android:name='.MainActivity' android:exported='true' android:permission='perm'/>
+        <service android:name='.MyService'/>
+        <receiver android:name='.MyReceiver' android:exported='false'/>
+        <provider android:name='.MyProvider' android:exported='true' android:permission='provider_perm'/>
+        <meta-data android:name='key' android:value='val'/>
+    </application>
+</manifest>
+"""
+
+
+def test_extract_permission_details():
+    details = extract_permission_details(MANIFEST)
+    assert {
+        "name": "android.permission.INTERNET",
+        "tag": "uses-permission",
+        "max_sdk_version": None,
+    } in details
+    assert {
+        "name": "android.permission.CAMERA",
+        "tag": "uses-permission-sdk-23",
+        "max_sdk_version": 28,
+    } in details
+
+
+def test_extract_permissions():
+    perms = extract_permissions(MANIFEST)
+    assert perms == ["android.permission.CAMERA", "android.permission.INTERNET"]
+
+
+def test_extract_components():
+    comps = extract_components(MANIFEST)
+    assert comps["activity"][0] == {
+        "name": ".MainActivity",
+        "exported": True,
+        "permission": "perm",
+    }
+    assert comps["service"][0] == {
+        "name": ".MyService",
+        "exported": False,
+        "permission": "",
+    }
+    assert comps["receiver"][0] == {
+        "name": ".MyReceiver",
+        "exported": False,
+        "permission": "",
+    }
+    assert comps["provider"][0] == {
+        "name": ".MyProvider",
+        "exported": True,
+        "permission": "provider_perm",
+    }
+
+
+def test_extract_sdk_info():
+    info = extract_sdk_info(MANIFEST)
+    assert info == {"minSdkVersion": 21, "targetSdkVersion": 33}
+
+
+def test_extract_features():
+    features = extract_features(MANIFEST)
+    assert features == [
+        {"name": "feature1", "required": True},
+        {"name": "feature2", "required": False},
+    ]
+
+
+def test_extract_app_flags():
+    flags = extract_app_flags(MANIFEST)
+    assert flags == {
+        "debuggable": True,
+        "allowBackup": False,
+        "usesCleartextTraffic": True,
+    }
+
+
+def test_extract_metadata():
+    metadata = extract_metadata(MANIFEST)
+    assert metadata == [{"name": "key", "value": "val"}]

--- a/testing/test_secrets.py
+++ b/testing/test_secrets.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from analysis import secrets
+from analysis.secrets import (
+    _contains_nul_bytes,
+    _is_text_file,
+    _load_text,
+    _shannon_entropy,
+    scan_for_secrets,
+)
+
+
+def test_shannon_entropy():
+    assert _shannon_entropy("") == 0.0
+    assert _shannon_entropy("aaaa") == 0.0
+    assert round(_shannon_entropy("abcd"), 3) == 2.0
+
+
+def test_is_text_file():
+    assert _is_text_file(Path("file.txt"))
+    assert not _is_text_file(Path("file.exe"))
+
+
+def test_contains_nul_bytes():
+    assert _contains_nul_bytes(b"a\x00b")
+    assert not _contains_nul_bytes(b"abc")
+
+
+def test_load_text_filters(tmp_path: Path, monkeypatch):
+    text_file = tmp_path / "sample.txt"
+    text_file.write_text("hello")
+    assert _load_text(text_file) == "hello"
+
+    bin_file = tmp_path / "bin.txt"
+    bin_file.write_bytes(b"\x00\x01")
+    assert _load_text(bin_file) is None
+
+    big_file = tmp_path / "big.txt"
+    big_file.write_text("x" * 10)
+    monkeypatch.setattr(secrets, "SIZE_LIMIT", 5)
+    assert _load_text(big_file) is None
+
+
+def test_scan_for_secrets_detects_keyword_and_entropy(tmp_path: Path):
+    token = "0123456789abcdefABCDEFghijkl"
+    # ensure our token has high entropy so entropy detector triggers
+    assert _shannon_entropy(token) > 4.5
+    test_file = tmp_path / "config.txt"
+    test_file.write_text(f"API_KEY=foo\n{token}\n")
+
+    results = scan_for_secrets(tmp_path)
+    assert f"{test_file.name}:0" in results
+    assert f"{test_file.name}:12" in results


### PR DESCRIPTION
## Summary
- add unit tests for Android manifest parsing
- add tests covering secret scanning utilities
- configure pytest with coverage defaults and run in CI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6f4bac8832785929b7fa24d9b3c