### PR TITLE
Add automated UI exploration and coverage metrics

### DIFF
--- a/cli/menu.py
+++ b/cli/menu.py
@@ -36,6 +36,7 @@ def run_main_menu() -> None:
         "Analyze a local APK for permissions and secrets",
         "Pull and analyze an installed app",
         "Sandbox analyze a local APK",
+        "Explore installed app UI",
     ]
 
     class _RefreshMenu(Exception):
@@ -69,6 +70,10 @@ def run_main_menu() -> None:
                 actions.analyze_installed_app(selected_serial)
         elif choice == 9:
             actions.sandbox_analyze_apk()
+        elif choice == 10:
+            selected_serial = _ensure_device_selected(selected_serial)
+            if selected_serial:
+                actions.explore_installed_app(selected_serial)
         else:
             display.warn(f"Unhandled choice: {choice}")
         raise _RefreshMenu

--- a/sandbox/metrics.py
+++ b/sandbox/metrics.py
@@ -10,6 +10,7 @@ def compute_runtime_metrics(
     permission_events: Iterable[str],
     network_events: Iterable[str],
     file_write_events: Iterable[str],
+    activity_events: Iterable[str] = (),
 ) -> Dict[str, Any]:
     """Aggregate sandbox execution data into simple metrics.
 
@@ -21,6 +22,10 @@ def compute_runtime_metrics(
         Iterable of network endpoints contacted (e.g., hostnames or URLs).
     file_write_events:
         Iterable of filesystem paths written to during execution.
+    activity_events:
+        Iterable of fully-qualified activity names visited during UI
+        exploration.  Defaults to an empty iterable if no coverage information
+        is available.
 
     Returns
     -------
@@ -35,10 +40,14 @@ def compute_runtime_metrics(
             Sorted list of unique network endpoints contacted and their count.
         ``filesystem_writes`` / ``filesystem_write_count``
             Sorted list of unique file paths written to and their count.
+        ``activities`` / ``activity_count``
+            Sorted list of unique activities exercised during automated UI
+            exploration and their count.
     """
     perm_counts = Counter(permission_events)
     endpoints = sorted(set(network_events))
     writes = sorted(set(file_write_events))
+    activities = sorted(set(activity_events))
 
     return {
         "permission_usage_counts": dict(perm_counts),
@@ -47,4 +56,6 @@ def compute_runtime_metrics(
         "network_endpoint_count": len(endpoints),
         "filesystem_writes": writes,
         "filesystem_write_count": len(writes),
+        "activities": activities,
+        "activity_count": len(activities),
     }

--- a/sandbox/ui_driver.py
+++ b/sandbox/ui_driver.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Automated UI exploration helpers using ``adb shell monkey``."""
+
+import re
+import subprocess
+from typing import List, Sequence, Set
+
+_ACTIVITY_CMP_RE = re.compile(r"cmp=([\w./$-]+)")
+_ACTIVITY_GENERIC_RE = re.compile(r"Activity\s*: ?([\w./$-]+)")
+
+
+def _parse_monkey_output(output: str, package: str) -> List[str]:
+    """Extract visited activities from monkey output.
+
+    Parameters
+    ----------
+    output:
+        Raw stdout/stderr combined output from the monkey process.
+    package:
+        Application package name. Used to resolve relative activity names and
+        filter out unrelated components.
+
+    Returns
+    -------
+    List[str]
+        Sorted list of unique activity names encountered during the run.
+    """
+    visited: Set[str] = set()
+    for line in output.splitlines():
+        match = _ACTIVITY_CMP_RE.search(line) or _ACTIVITY_GENERIC_RE.search(line)
+        if not match:
+            continue
+        component = match.group(1)
+        if component.startswith("." ):
+            component = package + component
+        if package and not component.startswith(package):
+            continue
+        visited.add(component)
+    return sorted(visited)
+
+
+def run_monkey(
+    serial: str,
+    package: str,
+    event_count: int = 1000,
+    extra_args: Sequence[str] | None = None,
+) -> List[str]:
+    """Drive the target app using Android's ``monkey`` tool.
+
+    This function invokes ``adb shell monkey`` for the specified package and
+    parses the output to determine which activities were visited.  The list of
+    unique activities is returned so that callers can incorporate coverage
+    metrics into reports.
+    """
+    cmd = ["adb"]
+    if serial:
+        cmd += ["-s", serial]
+    cmd += ["shell", "monkey", "-p", package, "-v"]
+    if extra_args:
+        cmd.extend(extra_args)
+    cmd.append(str(event_count))
+
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    return _parse_monkey_output(proc.stdout, package)
+
+
+__all__ = ["run_monkey"]

--- a/testing/test_sandbox_metrics.py
+++ b/testing/test_sandbox_metrics.py
@@ -8,10 +8,17 @@ def test_compute_runtime_metrics():
     ]
     network = ["https://example.com", "https://example.com", "https://other.com"]
     writes = ["/data/a.txt", "/data/b.txt", "/data/a.txt"]
-    metrics = compute_runtime_metrics(perms, network, writes)
+    activities = [
+        "com.example/.Main",
+        "com.example/.Settings",
+        "com.example/.Main",
+    ]
+    metrics = compute_runtime_metrics(perms, network, writes, activities)
     assert metrics["permission_usage_counts"]["android.permission.INTERNET"] == 2
     assert metrics["network_endpoints"] == ["https://example.com", "https://other.com"]
     assert metrics["filesystem_writes"] == ["/data/a.txt", "/data/b.txt"]
     assert metrics["unique_permission_count"] == 2
     assert metrics["network_endpoint_count"] == 2
     assert metrics["filesystem_write_count"] == 2
+    assert metrics["activities"] == ["com.example/.Main", "com.example/.Settings"]
+    assert metrics["activity_count"] == 2

--- a/testing/test_ui_driver.py
+++ b/testing/test_ui_driver.py
@@ -1,0 +1,23 @@
+import subprocess
+from types import SimpleNamespace
+
+from sandbox.ui_driver import run_monkey
+
+
+def test_run_monkey_parses_activity(monkeypatch):
+    sample_output = """
+    Monkey: seed=123 count=2
+    ActivityManager: Start proc 123:cmp=com.example/.MainActivity
+    Activity: com.example/.SettingsActivity
+    """
+
+    def fake_run(cmd, stdout, stderr, text, check):
+        return SimpleNamespace(stdout=sample_output)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    acts = run_monkey("serial", "com.example", event_count=2)
+    assert acts == [
+        "com.example/.MainActivity",
+        "com.example/.SettingsActivity",
+    ]


### PR DESCRIPTION
## Summary
- implement `sandbox.ui_driver.run_monkey` to exercise apps via `adb shell monkey` and extract visited activities
- track activity coverage in `compute_runtime_metrics` and expose totals
- add CLI entry to explore installed app UIs with coverage summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e816828483278298d5fd1ac542c2