### PR TITLE
Add centralized JSON logging with context metadata

### DIFF
--- a/cli/prompts.py
+++ b/cli/prompts.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from logging_config import get_logger
+
+
+logger = get_logger(__name__)
 
 def prompt_existing_path(prompt: str, cancel_message: str) -> Optional[str]:
     """Prompt user for a filesystem path until an existing path is provided.
@@ -15,9 +19,12 @@ def prompt_existing_path(prompt: str, cancel_message: str) -> Optional[str]:
     while True:
         path_str = input(prompt).strip()
         if not path_str:
+            logger.info("prompt canceled")
             print(cancel_message)
             return None
         if Path(path_str).exists():
+            logger.info("path provided", extra={"path": path_str})
             return path_str
+        logger.warning("path does not exist", extra={"path": path_str})
         print("Status: Provided path does not exist.")
 

--- a/core/errors.py
+++ b/core/errors.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Optional
 import xml.etree.ElementTree as ET
+
+from logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def log_exception(message: str, exc: Exception) -> None:
     """Log an exception with a standard format."""
-    logging.error("%s: %s", message, exc)
+    logger.error("%s: %s", message, exc)
 
 
 def safe_fromstring(xml_text: str, *, description: str = "XML") -> Optional[ET.Element]:

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,73 @@
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from contextlib import contextmanager
+import contextvars
+
+# Context variables for device and app metadata
+_device_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("device", default=None)
+_app_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("app", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON including context metadata."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
+        log_record = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "module": record.name,
+            "message": record.getMessage(),
+        }
+        device = _device_var.get()
+        app = _app_var.get()
+        if device:
+            log_record["device"] = device
+        if app:
+            log_record["app"] = app
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def _build_handler() -> logging.Handler:
+    """Create a rotating file handler writing to reports/logs/audit.log."""
+    log_dir = Path(__file__).resolve().parent / "reports" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    file_handler = RotatingFileHandler(
+        log_dir / "audit.log", maxBytes=1_000_000, backupCount=5
+    )
+    stream_handler = logging.StreamHandler()
+
+    formatter = JsonFormatter()
+    file_handler.setFormatter(formatter)
+    stream_handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)
+    return root
+
+
+_root_logger: logging.Logger = _build_handler()
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a configured logger with JSON formatting."""
+    return logging.getLogger(name)
+
+
+@contextmanager
+def log_context(*, device: str | None = None, app: str | None = None):
+    """Context manager to inject device/app metadata into log records."""
+    token_dev = _device_var.set(device) if device is not None else None
+    token_app = _app_var.set(app) if app is not None else None
+    try:
+        yield
+    finally:
+        if token_dev is not None:
+            _device_var.reset(token_dev)
+        if token_app is not None:
+            _app_var.reset(token_app)

--- a/main.py
+++ b/main.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 from cli import run_main_menu
+from logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def main() -> None:
     """Run the interactive CLI menu."""
+    logger.info("Launching CLI")
     run_main_menu()
 
 

--- a/sandbox/permission_monitor.py
+++ b/sandbox/permission_monitor.py
@@ -10,7 +10,6 @@ generation.
 
 from __future__ import annotations
 
-import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass
@@ -18,8 +17,9 @@ from datetime import datetime, timezone
 from typing import DefaultDict, Dict, Iterable, List
 
 from devices import adb
+from logging_config import get_logger, log_context
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def collect_permissions(apk_path: str) -> List[str]:
@@ -85,7 +85,8 @@ class PermissionMonitor:
             comp = match.group("comp")
             timestamp = datetime.now(tz=timezone.utc).isoformat()
             access = PermissionAccess(timestamp, perm, comp)
-            logger.info("%s | %s accessed by %s", timestamp, perm, comp)
+            with log_context(app=self.package):
+                logger.info("%s | %s accessed by %s", timestamp, perm, comp)
             self._summary[perm] += 1
             self._logs.append(access)
 


### PR DESCRIPTION
## Summary
- add `logging_config` that formats logs as JSON and writes rotating audit log
- use shared logger across modules and support device/app context
- log CLI and device discovery events via central logger

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6f699b48327b62ae64a3a403351