### PR TITLE
Add configuration loader and plugin registry

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration package providing file loading utilities."""
+
+from .loader import load, ConfigError
+
+__all__ = ["load", "ConfigError"]

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Utilities for loading configuration files."""
+
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+import json
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+
+class ConfigError(Exception):
+    """Raised when configuration loading or validation fails."""
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:  # pragma: no cover - pass through
+        raise ConfigError(f"Config file not found: {path}") from exc
+
+
+def _parse(text: str, suffix: str) -> MutableMapping[str, Any]:
+    if suffix in {".yml", ".yaml"}:
+        if yaml is None:
+            raise ConfigError("PyYAML is required for YAML configuration files")
+        data = yaml.safe_load(text) or {}
+    elif suffix == ".json":
+        data = json.loads(text or '{}')
+    else:
+        raise ConfigError(f"Unsupported config format: {suffix}")
+    if not isinstance(data, MutableMapping):
+        raise ConfigError("Configuration root must be a mapping")
+    return data
+
+
+def _validate(data: Mapping[str, Any], schema: Mapping[str, type] | None) -> None:
+    if schema is None:
+        return
+    for key, typ in schema.items():
+        if key not in data:
+            raise ConfigError(f"Missing required key: {key}")
+        if not isinstance(data[key], typ):
+            raise ConfigError(
+                f"Invalid type for '{key}': expected {typ.__name__}, got {type(data[key]).__name__}"
+            )
+
+
+def load(
+    path: str | Path,
+    schema: Mapping[str, type] | None = None,
+    defaults: Mapping[str, Any] | None = None,
+) -> MutableMapping[str, Any]:
+    """Load a JSON or YAML configuration file and validate against ``schema``.
+
+    ``defaults`` are merged with the loaded data (file values take precedence).
+    """
+    p = Path(path)
+    text = _read_text(p)
+    data = _parse(text, p.suffix.lower())
+    if defaults:
+        merged: MutableMapping[str, Any] = {**defaults, **data}
+    else:
+        merged = data
+    _validate(merged, schema)
+    return merged

--- a/core/config.py
+++ b/core/config.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from datetime import datetime
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, MutableMapping, Optional, Mapping
+
+from config.loader import load as _load_config
 
 # -----------------------------
 # App metadata
@@ -67,6 +70,45 @@ def ensure_dirs() -> None:
     """Create required directories if missing."""
     for d in (OUTPUT_DIR, LOGS_DIR, SCREENSHOTS_DIR):
         d.mkdir(parents=True, exist_ok=True)
+
+
+# -----------------------------
+# Global configuration
+# -----------------------------
+
+
+@dataclass
+class GlobalConfig:
+    """Container for runtime configuration loaded from file."""
+
+    data: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data[key]
+
+    def __contains__(self, key: str) -> bool:  # pragma: no cover - trivial
+        return key in self.data
+
+    def load(
+        self,
+        path: Optional[Path] = None,
+        *,
+        schema: Mapping[str, type] | None = None,
+        defaults: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Load configuration from ``path`` using :mod:`config.loader`."""
+        target = path or Path(os.getenv("AT_CONFIG", PROJECT_ROOT / "config.yaml"))
+        if target.exists():
+            self.data = _load_config(target, schema=schema, defaults=defaults)
+        else:
+            self.data = dict(defaults) if defaults else {}
+
+
+CONFIG = GlobalConfig()
+
 
 
 # -----------------------------
@@ -138,3 +180,7 @@ def debug_summary() -> str:
         f"SDK Root      : {get_sdk_root()}",
         f"ADB Path      : {get_adb_path()}",
     ])
+
+
+# Load configuration on import
+CONFIG.load()

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -1,0 +1,51 @@
+"""Simple plug-in registry for analyzer extensions."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from typing import Any, Callable, Dict
+
+_ANALYZERS: Dict[str, Callable[..., Any]] = {}
+
+
+def register(name: str, func: Callable[..., Any], *, replace: bool = False) -> None:
+    """Register an analyzer ``func`` under ``name``."""
+    if not replace and name in _ANALYZERS:
+        raise KeyError(f"Analyzer '{name}' already registered")
+    _ANALYZERS[name] = func
+
+
+def analyzer(name: str, *, replace: bool = False) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator variant of :func:`register`."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        register(name, func, replace=replace)
+        return func
+
+    return decorator
+
+
+def get(name: str) -> Callable[..., Any]:
+    """Return the analyzer registered under ``name``."""
+    return _ANALYZERS[name]
+
+
+def available() -> Dict[str, Callable[..., Any]]:
+    """Return all registered analyzers."""
+    return dict(_ANALYZERS)
+
+
+def clear() -> None:
+    """Remove all registered analyzers (primarily for tests)."""
+    _ANALYZERS.clear()
+
+
+def load_entry_point_plugins(group: str = "rotterdam.analyzers") -> None:
+    """Load plug-ins defined as entry points under ``group``."""
+    try:
+        eps = metadata.entry_points().select(group=group)
+    except Exception:  # pragma: no cover - compatibility
+        eps = []
+    for ep in eps:
+        if ep.name not in _ANALYZERS:
+            register(ep.name, ep.load())

--- a/testing/test_config_loader.py
+++ b/testing/test_config_loader.py
@@ -1,0 +1,33 @@
+import pytest
+
+from config.loader import load, ConfigError
+from core.config import GlobalConfig
+
+
+def test_load_with_schema_and_defaults(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('{"a": 1}')
+    data = load(cfg, schema={"a": int, "b": str}, defaults={"b": "x"})
+    assert data["a"] == 1
+    assert data["b"] == "x"
+
+
+def test_load_missing_key_raises(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('{"a": 1}')
+    with pytest.raises(ConfigError):
+        load(cfg, schema={"a": int, "b": int})
+
+
+def test_global_config_load(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('{"port": 42}')
+    gc = GlobalConfig()
+    gc.load(cfg, schema={"port": int})
+    assert gc["port"] == 42
+
+
+def test_global_config_defaults(tmp_path):
+    gc = GlobalConfig()
+    gc.load(tmp_path / "missing.json", defaults={"debug": True})
+    assert gc["debug"] is True

--- a/testing/test_plugin_registry.py
+++ b/testing/test_plugin_registry.py
@@ -1,0 +1,49 @@
+import pytest
+
+from core import plugins
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    plugins.clear()
+    yield
+    plugins.clear()
+
+
+def test_register_and_get():
+    def sample():
+        return 1
+    plugins.register("sample", sample)
+    assert plugins.get("sample")() == 1
+
+
+def test_decorator_register():
+    @plugins.analyzer("decorated")
+    def decorated():
+        return 2
+    assert plugins.get("decorated")() == 2
+
+
+def test_duplicate_register_raises():
+    def dup():
+        pass
+    plugins.register("dup", dup)
+    with pytest.raises(KeyError):
+        plugins.register("dup", dup)
+
+
+def test_load_entry_point_plugins(monkeypatch):
+    class EP:
+        def __init__(self, name):
+            self.name = name
+        def load(self):
+            return lambda: "loaded"
+
+    class Eps:
+        def select(self, group):
+            assert group == "rotterdam.analyzers"
+            return [EP("ep1")]
+
+    monkeypatch.setattr(plugins.metadata, "entry_points", lambda: Eps())
+    plugins.load_entry_point_plugins()
+    assert "ep1" in plugins.available()


### PR DESCRIPTION
## Summary
- extend config loader with default merging and schema validation
- expose GlobalConfig as mapping with schema/default support
- enhance plug-in registry with decorator, duplicate protection, and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6f6f4088327bed6398dbb91ec95