### PR TITLE
Add device analytics and job management to API and UI

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server package exposing API for device enumeration, job submission, and report retrieval."""

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,172 @@
+"""FastAPI application exposing minimal API for Rotterdam."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from uuid import uuid4
+import time
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi import Response
+from pydantic import BaseModel
+
+from devices.discovery import list_detailed_devices
+from risk_scoring.risk_score import calculate_risk_score
+
+from .middleware import AuthRateLimitMiddleware
+from threading import Thread
+
+app = FastAPI(title="Rotterdam API")
+app.add_middleware(AuthRateLimitMiddleware)
+
+
+class JobRequest(BaseModel):
+    """Request body for a job submission."""
+
+    serial: str
+    static_metrics: Dict[str, float] | None = None
+    dynamic_metrics: Dict[str, float] | None = None
+    params: Dict[str, Any] | None = None
+
+
+_jobs: Dict[str, Dict[str, Any]] = {}
+
+
+@app.get("/devices")
+async def get_devices() -> list[Dict[str, Any]]:
+    """Enumerate connected devices.
+
+    If ADB or device discovery fails, return an empty list instead of raising
+    so the API remains usable in environments without Android tools."""
+    try:
+        return list_detailed_devices()
+    except Exception:
+        return []
+
+
+def _process_job(job_id: str, req: JobRequest) -> None:
+    """Simulate job processing and populate the report."""
+    # Simulate some work taking a bit of time
+    time.sleep(0.5)
+    score = calculate_risk_score(req.static_metrics, req.dynamic_metrics)
+    _jobs[job_id]["report"] = {
+        "status": "completed",
+        "risk": score,
+        "params": req.params or {},
+    }
+
+
+@app.post("/jobs")
+async def submit_job(req: JobRequest) -> Dict[str, str]:
+    """Submit a job for processing and return a job ID."""
+    job_id = str(uuid4())
+    _jobs[job_id] = {
+        "request": req.model_dump(),
+        "report": None,
+        "created": time.time(),
+    }
+    Thread(target=_process_job, args=(job_id, req), daemon=True).start()
+    return {"job_id": job_id}
+
+
+@app.get("/jobs")
+async def list_jobs() -> list[Dict[str, Any]]:
+    """Return all submitted jobs with their status."""
+    jobs = []
+    for jid, job in _jobs.items():
+        jobs.append(
+            {
+                "job_id": jid,
+                "status": "completed" if job["report"] else "pending",
+                "created": job["created"],
+            }
+        )
+    return jobs
+
+
+@app.get("/jobs/{job_id}")
+async def get_job(job_id: str) -> Dict[str, Any]:
+    """Return details for a single job."""
+    job = _jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {
+        "job_id": job_id,
+        "status": "completed" if job["report"] else "pending",
+        "created": job["created"],
+        "request": job["request"],
+    }
+
+
+@app.delete("/jobs/{job_id}", status_code=204)
+async def delete_job(job_id: str) -> Response:
+    """Remove a job and its report."""
+    if job_id not in _jobs:
+        raise HTTPException(status_code=404, detail="Job not found")
+    del _jobs[job_id]
+    return Response(status_code=204)
+
+
+@app.get("/reports/{job_id}")
+async def get_report(job_id: str) -> Dict[str, Any]:
+    """Retrieve a report for a given job ID."""
+    job = _jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["report"] is None:
+        return JSONResponse(status_code=202, content={"status": "pending"})
+    return {"job_id": job_id, "report": job["report"]}
+
+
+@app.get("/reports")
+async def list_reports() -> list[Dict[str, Any]]:
+    """Return all completed reports."""
+    reports = []
+    for jid, job in _jobs.items():
+        if job["report"]:
+            reports.append({"job_id": jid, **job["report"]})
+    return reports
+
+
+@app.get("/analytics")
+async def get_analytics() -> Dict[str, Any]:
+    """Compute simple analytics for completed reports."""
+    scores = [job["report"]["risk"]["score"] for job in _jobs.values() if job["report"]]
+    if not scores:
+        return {
+            "average_score": None,
+            "reports": 0,
+            "min_score": None,
+            "max_score": None,
+        }
+    avg = sum(scores) / len(scores)
+    return {
+        "average_score": avg,
+        "reports": len(scores),
+        "min_score": min(scores),
+        "max_score": max(scores),
+    }
+
+
+@app.get("/analytics/devices")
+async def get_device_analytics() -> list[Dict[str, Any]]:
+    """Compute analytics grouped by device serial."""
+    per_device: Dict[str, list[float]] = {}
+    for job in _jobs.values():
+        if job["report"]:
+            serial = job["request"].get("serial", "unknown")
+            score = job["report"]["risk"]["score"]
+            per_device.setdefault(serial, []).append(score)
+    results = []
+    for serial, scores in per_device.items():
+        results.append(
+            {
+                "serial": serial,
+                "reports": len(scores),
+                "average_score": sum(scores) / len(scores),
+                "min_score": min(scores),
+                "max_score": max(scores),
+            }
+        )
+    return results

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,0 +1,38 @@
+"""Authentication and rate-limiting middleware for the API."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Callable
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Simple API key used for demonstration. In production load from config.
+API_KEY = "secret"
+
+# Allow up to 60 requests per minute per client IP.
+RATE_LIMIT = 60
+
+# Track timestamps of requests per client IP.
+_request_log: dict[str, list[float]] = defaultdict(list)
+
+
+class AuthRateLimitMiddleware(BaseHTTPMiddleware):
+    """Validate an API key and apply naive rate limiting."""
+
+    async def dispatch(self, request: Request, call_next: Callable):
+        key = request.headers.get("X-API-Key")
+        if key != API_KEY:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        client_ip = request.client.host if request.client else "anonymous"
+        now = time.time()
+        window = [ts for ts in _request_log[client_ip] if now - ts < 60]
+        if len(window) >= RATE_LIMIT:
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+        window.append(now)
+        _request_log[client_ip] = window
+
+        return await call_next(request)

--- a/testing/test_server_api.py
+++ b/testing/test_server_api.py
@@ -1,0 +1,86 @@
+"""Tests for the FastAPI server endpoints."""
+
+import time
+
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+client = TestClient(app)
+HEADERS = {"X-API-Key": "secret"}
+
+
+def test_job_lifecycle():
+    # Devices endpoint should always return a list
+    resp = client.get("/devices", headers=HEADERS)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+    # Submit a job with some metrics
+    payload = {
+        "serial": "ABC",
+        "static_metrics": {"permission_density": 0.6},
+        "dynamic_metrics": {"permission_invocation_count": 15},
+    }
+    resp = client.post("/jobs", json=payload, headers=HEADERS)
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+    assert job_id
+
+    # Report should initially be pending
+    resp = client.get(f"/reports/{job_id}", headers=HEADERS)
+    assert resp.status_code == 202
+
+    # After background task completes, report should be available
+    time.sleep(0.6)
+    resp = client.get(f"/reports/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["job_id"] == job_id
+    assert data["report"]["status"] == "completed"
+    assert "risk" in data["report"]
+    assert "score" in data["report"]["risk"]
+
+    # Jobs endpoint should list the completed job
+    resp = client.get("/jobs", headers=HEADERS)
+    assert resp.status_code == 200
+    jobs = resp.json()
+    assert any(j["job_id"] == job_id and j["status"] == "completed" for j in jobs)
+
+    # Job detail endpoint should return information
+    resp = client.get(f"/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200
+    job_detail = resp.json()
+    assert job_detail["job_id"] == job_id
+    assert job_detail["status"] == "completed"
+
+    # Reports endpoint should include the job's report
+    resp = client.get("/reports", headers=HEADERS)
+    assert resp.status_code == 200
+    reports = resp.json()
+    assert any(r["job_id"] == job_id for r in reports)
+
+    # Analytics endpoint should compute averages
+    resp = client.get("/analytics", headers=HEADERS)
+    assert resp.status_code == 200
+    analytics = resp.json()
+    assert analytics["reports"] >= 1
+    assert analytics["average_score"] is not None
+    assert analytics["min_score"] is not None
+    assert analytics["max_score"] is not None
+
+    # Device analytics should group by serial
+    resp = client.get("/analytics/devices", headers=HEADERS)
+    assert resp.status_code == 200
+    device_stats = resp.json()
+    assert any(s["serial"] == "ABC" and s["reports"] >= 1 for s in device_stats)
+
+    # Deleting a job removes it
+    resp = client.delete(f"/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 204
+    resp = client.get(f"/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 404
+    resp = client.get(f"/reports/{job_id}", headers=HEADERS)
+    assert resp.status_code == 404
+

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rotterdam Dashboard</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script type="module" src="./main.js"></script>
+      <style>
+        body {
+          font-family: sans-serif;
+          margin: 2rem;
+        }
+        table {
+          border-collapse: collapse;
+        }
+        th,
+        td {
+          border: 1px solid #ccc;
+          padding: 0.5rem;
+        }
+        nav button {
+          margin-right: 0.5rem;
+        }
+      </style>
+    </head>
+    <body>
+      <div id="root"></div>
+    </body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,480 @@
+import React from "https://unpkg.com/react@18/umd/react.development.js";
+import ReactDOM from "https://unpkg.com/react-dom@18/umd/react-dom.development.js";
+
+const API_HEADERS = { "X-API-Key": "secret" };
+
+function DevicesPage() {
+  const [devices, setDevices] = React.useState([]);
+  React.useEffect(() => {
+    fetch("/devices", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then(setDevices)
+      .catch(console.error);
+  }, []);
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Devices"),
+    React.createElement(
+      "table",
+      null,
+      React.createElement(
+        "thead",
+        null,
+        React.createElement(
+          "tr",
+          null,
+          React.createElement("th", null, "Serial"),
+          React.createElement("th", null, "Model"),
+          React.createElement("th", null, "Release"),
+          React.createElement("th", null, "Rooted")
+        )
+      ),
+      React.createElement(
+        "tbody",
+        null,
+        devices.map((d) =>
+          React.createElement(
+            "tr",
+            { key: d.serial },
+            React.createElement("td", null, d.serial),
+            React.createElement("td", null, d.model || "-"),
+            React.createElement("td", null, d.android_release || "-"),
+            React.createElement("td", null, d.is_rooted ? "yes" : "no")
+          )
+        )
+      )
+    )
+  );
+}
+
+function AnalyzePage() {
+  const [devices, setDevices] = React.useState([]);
+  const [selected, setSelected] = React.useState("");
+  const [jobId, setJobId] = React.useState("");
+  const [report, setReport] = React.useState(null);
+  const [status, setStatus] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("/devices", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then((list) => {
+        setDevices(list);
+        if (list.length > 0) setSelected(list[0].serial);
+      })
+      .catch(console.error);
+  }, []);
+
+  const submitJob = async () => {
+    const payload = {
+      serial: selected,
+      static_metrics: { permission_density: Math.random() },
+      dynamic_metrics: { permission_invocation_count: Math.floor(Math.random() * 20) },
+    };
+    const res = await fetch("/jobs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...API_HEADERS },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    setJobId(data.job_id);
+    setReport(null);
+    setStatus("pending");
+  };
+
+  React.useEffect(() => {
+    if (!jobId) return;
+    const id = setInterval(async () => {
+      const res = await fetch(`/reports/${jobId}`, { headers: API_HEADERS });
+      if (res.status === 200) {
+        const data = await res.json();
+        setReport(data.report);
+        setStatus("completed");
+        clearInterval(id);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [jobId]);
+
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(
+      "div",
+      null,
+      React.createElement(
+        "select",
+        {
+          value: selected,
+          onChange: (e) => setSelected(e.target.value),
+        },
+        devices.map((d) =>
+          React.createElement("option", { key: d.serial, value: d.serial }, d.serial)
+        )
+      ),
+      React.createElement(
+        "button",
+        { onClick: submitJob, disabled: !selected },
+        "Analyze"
+      ),
+      jobId && React.createElement("span", null, ` Job: ${status || "pending"}`)
+    ),
+    report
+      ? React.createElement(
+          "div",
+          null,
+          React.createElement("h3", null, `Risk Score: ${report.risk.score}`),
+          React.createElement("p", null, report.risk.rationale),
+          React.createElement(
+            "table",
+            null,
+            React.createElement(
+              "tbody",
+              null,
+              Object.entries(report.risk.breakdown).map(([k, v]) =>
+                React.createElement(
+                  "tr",
+                  { key: k },
+                  React.createElement("td", null, k),
+                  React.createElement("td", null, v)
+                )
+              )
+            )
+          )
+        )
+      : React.createElement("pre", null, JSON.stringify(devices, null, 2))
+  );
+}
+
+function JobsPage() {
+  const [jobs, setJobs] = React.useState([]);
+  const load = () => {
+    fetch("/jobs", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then(setJobs)
+      .catch(console.error);
+  };
+  React.useEffect(load, []);
+  const remove = async (id) => {
+    await fetch(`/jobs/${id}`, { method: "DELETE", headers: API_HEADERS });
+    load();
+  };
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Jobs"),
+    React.createElement(
+      "table",
+      null,
+      React.createElement(
+        "thead",
+        null,
+        React.createElement(
+          "tr",
+          null,
+          React.createElement("th", null, "Job ID"),
+          React.createElement("th", null, "Status"),
+          React.createElement("th", null, "Actions")
+        )
+      ),
+      React.createElement(
+        "tbody",
+        null,
+        jobs.map((j) =>
+          React.createElement(
+            "tr",
+            { key: j.job_id },
+            React.createElement("td", null, j.job_id),
+            React.createElement("td", null, j.status),
+            React.createElement(
+              "td",
+              null,
+              React.createElement(
+                "button",
+                { onClick: () => remove(j.job_id) },
+                "Delete"
+              )
+            )
+          )
+        )
+      )
+    )
+  );
+}
+
+function ReportsPage({ onSelect }) {
+  const [reports, setReports] = React.useState([]);
+  React.useEffect(() => {
+    fetch("/reports", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then(setReports)
+      .catch(console.error);
+  }, []);
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Reports"),
+    React.createElement(
+      "table",
+      null,
+      React.createElement(
+        "thead",
+        null,
+        React.createElement(
+          "tr",
+          null,
+          React.createElement("th", null, "Job ID"),
+          React.createElement("th", null, "Score")
+        )
+      ),
+      React.createElement(
+        "tbody",
+        null,
+        reports.map((r) =>
+          React.createElement(
+            "tr",
+            {
+              key: r.job_id,
+              onClick: () => onSelect && onSelect(r.job_id),
+              style: { cursor: "pointer" },
+            },
+            React.createElement("td", null, r.job_id),
+            React.createElement("td", null, r.risk.score)
+          )
+        )
+      )
+    )
+  );
+}
+
+function AnalyticsPage() {
+  const [analytics, setAnalytics] = React.useState(null);
+  React.useEffect(() => {
+    fetch("/analytics", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then(setAnalytics)
+      .catch(console.error);
+  }, []);
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Analytics"),
+    analytics &&
+      React.createElement(
+        "ul",
+        null,
+        React.createElement("li", null, `Reports: ${analytics.reports}`),
+        React.createElement(
+          "li",
+          null,
+          `Average Score: ${analytics.average_score ?? "n/a"}`
+        ),
+        React.createElement(
+          "li",
+          null,
+          `Min Score: ${analytics.min_score ?? "n/a"}`
+        ),
+        React.createElement(
+          "li",
+          null,
+          `Max Score: ${analytics.max_score ?? "n/a"}`
+        )
+      )
+  );
+}
+
+function DeviceStatsPage() {
+  const [stats, setStats] = React.useState([]);
+  React.useEffect(() => {
+    fetch("/analytics/devices", { headers: API_HEADERS })
+      .then((r) => r.json())
+      .then(setStats)
+      .catch(console.error);
+  }, []);
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Device Stats"),
+    React.createElement(
+      "table",
+      null,
+      React.createElement(
+        "thead",
+        null,
+        React.createElement(
+          "tr",
+          null,
+          React.createElement("th", null, "Serial"),
+          React.createElement("th", null, "Reports"),
+          React.createElement("th", null, "Average"),
+          React.createElement("th", null, "Min"),
+          React.createElement("th", null, "Max")
+        )
+      ),
+      React.createElement(
+        "tbody",
+        null,
+        stats.map((s) =>
+          React.createElement(
+            "tr",
+            { key: s.serial },
+            React.createElement("td", null, s.serial),
+            React.createElement("td", null, s.reports),
+            React.createElement("td", null, s.average_score),
+            React.createElement("td", null, s.min_score),
+            React.createElement("td", null, s.max_score)
+          )
+        )
+      )
+    )
+  );
+}
+
+function ReportDetailPage({ jobId, onBack }) {
+  const [id, setId] = React.useState(jobId || "");
+  const [detail, setDetail] = React.useState(null);
+  const load = async (jid) => {
+    if (!jid) return;
+    try {
+      const reportRes = await fetch(`/reports/${jid}`, { headers: API_HEADERS });
+      if (reportRes.status !== 200) {
+        setDetail(null);
+        return;
+      }
+      const reportData = await reportRes.json();
+      const jobRes = await fetch(`/jobs/${jid}`, { headers: API_HEADERS });
+      const jobData = jobRes.status === 200 ? await jobRes.json() : null;
+      setDetail({ report: reportData.report, job: jobData });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+  React.useEffect(() => {
+    if (jobId) load(jobId);
+  }, [jobId]);
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, "Report Detail"),
+    React.createElement(
+      "div",
+      null,
+      React.createElement("input", {
+        value: id,
+        onChange: (e) => setId(e.target.value),
+        placeholder: "Job ID",
+      }),
+      React.createElement(
+        "button",
+        { onClick: () => load(id), disabled: !id },
+        "Load"
+      ),
+      onBack &&
+        React.createElement(
+          "button",
+          { onClick: onBack, style: { marginLeft: "0.5rem" } },
+          "Back"
+        )
+    ),
+    detail &&
+      detail.report &&
+      React.createElement(
+        "div",
+        null,
+        React.createElement(
+          "h4",
+          null,
+          `Risk Score: ${detail.report.risk.score}`
+        ),
+        React.createElement("p", null, detail.report.risk.rationale),
+        React.createElement(
+          "table",
+          null,
+          React.createElement(
+            "tbody",
+            null,
+            Object.entries(detail.report.risk.breakdown).map(([k, v]) =>
+              React.createElement(
+                "tr",
+                { key: k },
+                React.createElement("td", null, k),
+                React.createElement("td", null, v)
+              )
+            )
+          )
+        ),
+        detail.job &&
+          detail.job.request &&
+          React.createElement(
+            "pre",
+            null,
+            JSON.stringify(detail.job.request, null, 2)
+          )
+      )
+  );
+}
+
+function App() {
+  const [page, setPage] = React.useState("home");
+  const [detailId, setDetailId] = React.useState("");
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h1", null, "Rotterdam UI"),
+    React.createElement(
+      "nav",
+      null,
+      React.createElement(
+        "button",
+        { onClick: () => setPage("home") },
+        "Analyze"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => setPage("devices") },
+        "Devices"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => setPage("jobs") },
+        "Jobs"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => setPage("reports") },
+        "Reports"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => setPage("analytics") },
+        "Analytics"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => setPage("deviceStats") },
+        "Device Stats"
+      )
+    ),
+    page === "home" && React.createElement(AnalyzePage),
+    page === "devices" && React.createElement(DevicesPage),
+    page === "jobs" && React.createElement(JobsPage),
+    page === "reports" &&
+      React.createElement(ReportsPage, {
+        onSelect: (jid) => {
+          setDetailId(jid);
+          setPage("reportDetail");
+        },
+      }),
+    page === "analytics" && React.createElement(AnalyticsPage),
+    page === "deviceStats" && React.createElement(DeviceStatsPage),
+    page === "reportDetail" &&
+      React.createElement(ReportDetailPage, {
+        jobId: detailId,
+        onBack: () => setPage("reports"),
+      })
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  React.createElement(App)
+);


### PR DESCRIPTION
## Summary
- expose per-device analytics endpoint and job deletion API
- show job delete controls and a device stats page in the React dashboard
- expand API tests for device analytics and job removal

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e8196c048327a6c7ec916c38708d