### PR TITLE
Support MySQL configuration with pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ Rotterdam is a toolkit for analyzing Android applications and devices. It provid
 
 Set up a Python environment and install the project's dependencies.
 
+### Database configuration
+
+The repository uses SQLAlchemy for persistence. By default an in-memory
+SQLite database is used, but MySQL is also supported. Configure the database
+connection in one of two ways:
+
+1. Provide a full SQLAlchemy URL via ``DATABASE_URL``::
+
+   ``export DATABASE_URL="mysql+pymysql://user:pass@host/db"``
+
+2. Set individual MySQL parameters and they will be assembled into a URL::
+
+   ``export DB_USER=user``
+   ``export DB_PASSWORD=secret``
+   ``export DB_HOST=localhost``
+   ``export DB_PORT=3306``
+   ``export DB_NAME=rotterdam``
+
+Connection pooling is enabled by default and basic error handling will surface
+initialisation failures early.
+
 ## Running tests
 
 ```bash

--- a/core/config.py
+++ b/core/config.py
@@ -111,6 +111,38 @@ class GlobalConfig:
 CONFIG = GlobalConfig()
 
 
+# -----------------------------
+# Database configuration
+# -----------------------------
+
+
+def get_database_url() -> str:
+    """Return a SQLAlchemy database URL constructed from the environment.
+
+    The resolution order is:
+
+    1. ``DATABASE_URL`` if set.
+    2. Individual MySQL settings (``DB_USER``, ``DB_PASSWORD``, ``DB_HOST``,
+       ``DB_PORT``, ``DB_NAME``).
+    3. Fallback to an in-memory SQLite database.
+    """
+
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+
+    user = os.getenv("DB_USER")
+    name = os.getenv("DB_NAME")
+    if user and name:
+        password = os.getenv("DB_PASSWORD", "")
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "3306")
+        auth = f":{password}" if password else ""
+        return f"mysql+pymysql://{user}{auth}@{host}:{port}/{name}"
+
+    return "sqlite:///:memory:"
+
+
 
 # -----------------------------
 # Timestamp helpers


### PR DESCRIPTION
## Summary
- add environment-based database configuration resolving `DATABASE_URL` or individual MySQL params
- provide connection pooling and error handling in repository initialisation
- document MySQL setup in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3f35657e483279c8fee5572fbc099