### PR TITLE
Add rule engine for Android static analysis

### DIFF
--- a/analysis/report.py
+++ b/analysis/report.py
@@ -132,6 +132,7 @@ def write_report(
     dynamic_metrics: Dict[str, Any] | None = None,
     yara_matches: Dict[str, List[str]] | None = None,
     diff: Dict[str, Any] | None = None,
+    findings: List[Dict[str, Any]] | None = None,
 ) -> Path:
     """Write a JSON report containing analysis results."""
     report_path = out / "report.json"
@@ -152,6 +153,8 @@ def write_report(
         data["yara_matches"] = yara_matches
     if diff is not None:
         data["diff"] = diff
+    if findings is not None:
+        data["findings"] = findings
 
     report_path.write_text(json.dumps(data, indent=2))
     return report_path

--- a/analysis/rules_engine.py
+++ b/analysis/rules_engine.py
@@ -1,0 +1,80 @@
+"""Simple rule engine for evaluating analysis facts against YAML-defined rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import yaml
+
+try:  # pragma: no cover - optional dependency
+    import jmespath
+except Exception:  # pragma: no cover - gracefully handle missing lib
+    jmespath = None
+
+
+@dataclass
+class Rule:
+    """Representation of a single rule loaded from YAML."""
+
+    id: str
+    severity: str
+    selector: str
+    remediation: str
+
+
+def load_rules(rule_dir: Path) -> List[Rule]:
+    """Load all rules from ``rule_dir``.
+
+    Each YAML file may contain a top-level ``rules`` list or be a list itself.
+    """
+    rules: List[Rule] = []
+    for path in rule_dir.glob("*.y*ml"):
+        data = yaml.safe_load(path.read_text()) or {}
+        items: Iterable[Dict[str, Any]]
+        if isinstance(data, dict):
+            items = data.get("rules", [])
+        elif isinstance(data, list):
+            items = data
+        else:  # pragma: no cover - malformed yaml
+            continue
+        for item in items:
+            try:
+                rules.append(
+                    Rule(
+                        id=str(item.get("id", Path(path).stem)),
+                        severity=str(item.get("severity", "info")),
+                        selector=str(item.get("selector", "")),
+                        remediation=str(item.get("remediation", "")),
+                    )
+                )
+            except Exception:  # pragma: no cover - skip invalid entries
+                continue
+    return rules
+
+
+def evaluate_rules(rules: List[Rule], facts: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Evaluate ``rules`` against ``facts`` and return findings."""
+    findings: List[Dict[str, Any]] = []
+    for rule in rules:
+        if not rule.selector:
+            continue
+        result: Any = None
+        try:
+            if jmespath is not None:
+                result = jmespath.search(rule.selector, facts)
+            else:  # pragma: no cover - jmespath missing
+                result = facts.get(rule.selector)
+        except Exception:  # pragma: no cover - selector errors
+            continue
+        if result:
+            findings.append(
+                {
+                    "id": rule.id,
+                    "severity": rule.severity,
+                    "remediation": rule.remediation,
+                    "matches": result,
+                }
+            )
+    return findings

--- a/analysis/static.py
+++ b/analysis/static.py
@@ -21,6 +21,7 @@ from .permissions import categorize_permissions
 from .secrets import scan_for_secrets
 from .report import calculate_derived_metrics, write_report
 from .diff import diff_snapshots
+from .rules_engine import load_rules, evaluate_rules
 
 # Optional imports (degrade gracefully if unavailable)
 try:
@@ -121,6 +122,27 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
         perm_details, components, sdk_info, features, metadata
     )
 
+    # Evaluate rules against collected facts
+    findings: List[Dict[str, Any]] = []
+    try:
+        rule_dir = Path(__file__).resolve().parent.parent / "rules" / "android"
+        rules = load_rules(rule_dir)
+        facts = {
+            "permissions": perms,
+            "permission_details": perm_details,
+            "components": components,
+            "sdk_info": sdk_info,
+            "features": features,
+            "app_flags": app_flags,
+            "metadata": metadata,
+            "metrics": metrics,
+        }
+        findings = evaluate_rules(rules, facts)
+        if findings:
+            (out / "findings.json").write_text(json.dumps(findings, indent=2))
+    except Exception as e:  # pragma: no cover
+        display.warn(f"Rule evaluation failed: {e}")
+
     # Optional signature verification (if available)
     if verify_signature:
         try:
@@ -175,6 +197,7 @@ def analyze_apk(apk_path: str, outdir: str = "analysis") -> Path:
         risk,             # placed into "metrics" bucket as additional fields
         yara_matches,
         diff,
+        findings,
     )
 
     return out

--- a/rules/android/manifest_rules.yaml
+++ b/rules/android/manifest_rules.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: dangerous_permissions
+    severity: medium
+    selector: permission_details[?dangerous].name[]
+    remediation: Review dangerous permissions and remove those not required.
+  - id: exported_components
+    severity: high
+    selector: components.*[?exported==`true`].name[]
+    remediation: Restrict exported components or protect them with permissions.


### PR DESCRIPTION
## Summary
- add YAML rule pack for Android manifest checks
- create rule engine to evaluate JMESPath selectors
- integrate engine into static analysis and store findings in reports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f35b14708327b2af23e1d3c20587