### PR TITLE
feat: add configurable frida hook loader

### DIFF
--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -1,0 +1,40 @@
+"""Command-line interface for running sandbox analysis with configurable hooks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .runtime import run_analysis
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run sandbox analysis")
+    parser.add_argument("apk", help="Path to APK file to analyze")
+    parser.add_argument("outdir", help="Directory to store analysis artifacts")
+    parser.add_argument(
+        "--enable-hook",
+        action="append",
+        dest="enable_hooks",
+        default=None,
+        help="Enable only the specified hook. Can be used multiple times.",
+    )
+    parser.add_argument(
+        "--disable-hook",
+        action="append",
+        dest="disable_hooks",
+        default=None,
+        help="Disable the specified hook. Can be used multiple times.",
+    )
+    args = parser.parse_args(argv)
+
+    run_analysis(
+        args.apk,
+        Path(args.outdir),
+        enable_hooks=args.enable_hooks,
+        disable_hooks=args.disable_hooks,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/sandbox/frida_loader.py
+++ b/sandbox/frida_loader.py
@@ -1,0 +1,26 @@
+"""Utilities for discovering and selecting Frida hook scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+
+def discover_scripts(scripts_dir: Path | None = None) -> List[str]:
+    """Return a sorted list of available hook script names without extension."""
+    scripts_dir = scripts_dir or Path(__file__).with_name("frida_scripts")
+    return sorted(p.stem for p in scripts_dir.glob("*.js"))
+
+
+def resolve_hooks(
+    enabled: Iterable[str] | None = None,
+    disabled: Iterable[str] | None = None,
+    scripts_dir: Path | None = None,
+) -> List[str]:
+    """Determine which hooks to load based on enabled/disabled lists."""
+    available = set(discover_scripts(scripts_dir))
+    hooks = set(enabled) if enabled is not None else set(available)
+    hooks &= available  # ensure all exist
+    if disabled:
+        hooks.difference_update(disabled)
+    return sorted(hooks)

--- a/sandbox/runner.py
+++ b/sandbox/runner.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Dict, List, Tuple, Any
 
 from .instrumentation import FridaInstrumentation
 from .metrics import compute_runtime_metrics
 
 
-def run_sandbox(apk_path: str, outdir: Path, *, hooks: Iterable[str] | None = None) -> Path:
+def run_sandbox(
+    apk_path: str, outdir: Path, *, hooks: Iterable[str] | None = None
+) -> Tuple[Path, Dict[str, Any], List[str]]:
     """Simulate running an APK inside a sandbox.
 
     Parameters
@@ -24,26 +25,25 @@ def run_sandbox(apk_path: str, outdir: Path, *, hooks: Iterable[str] | None = No
 
     Returns
     -------
-    Path
-        Path to the created log file.
+    Tuple[Path, Dict[str, Any], List[str]]
+        Path to the created log file, collected runtime metrics and raw
+        messages emitted by instrumentation hooks.
     """
     outdir.mkdir(parents=True, exist_ok=True)
     hooks = list(hooks or [])
-    metrics_data = {}
+    metrics_data: Dict[str, Any] = {}
+    messages: List[str] = []
 
     # Load instrumentation and stream events into the metrics collector.
     with FridaInstrumentation(hooks) as instr:
-        events = list(instr.stream_events())
-        if events:
-            perm_events = [e.split(":", 1)[1] for e in events if e.startswith("PERMISSION:")]
-            net_events = [e.split(":", 1)[1] for e in events if e.startswith("NETWORK:")]
-            file_events = [e.split(":", 1)[1] for e in events if e.startswith("FILE_WRITE:")]
+        messages = list(instr.stream_events())
+        if messages:
+            perm_events = [e.split(":", 1)[1] for e in messages if e.startswith("PERMISSION:")]
+            net_events = [e.split(":", 1)[1] for e in messages if e.startswith("NETWORK:")]
+            file_events = [e.split(":", 1)[1] for e in messages if e.startswith("FILE_WRITE:")]
             metrics_data = compute_runtime_metrics(perm_events, net_events, file_events)
 
     log = outdir / "sandbox.log"
     log.write_text(f"Executed sandbox for {apk_path}\n")
 
-    if metrics_data:
-        (outdir / "metrics.json").write_text(json.dumps(metrics_data, indent=2))
-
-    return log
+    return log, metrics_data, messages

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Iterable
 
 from .runner import run_sandbox
 from .permission_monitor import collect_permissions
 from .network import sniff_network
+from .frida_loader import resolve_hooks
 
 
-def run_analysis(apk_path: str, outdir: Path) -> Dict[str, Any]:
+def run_analysis(
+    apk_path: str,
+    outdir: Path,
+    *,
+    enable_hooks: Iterable[str] | None = None,
+    disable_hooks: Iterable[str] | None = None,
+) -> Dict[str, Any]:
     """Run sandbox, permission monitor and network capture for an APK.
 
     Parameters
@@ -25,15 +32,27 @@ def run_analysis(apk_path: str, outdir: Path) -> Dict[str, Any]:
     -------
     Dict[str, Any]
         Dictionary containing paths and collected findings:
-        ``{"log": Path, "permissions": List[str], "network": List[Dict[str, str]]}``
+        ``{"log": Path, "permissions": List[str], "network": List[Dict[str, str]],
+        "metrics": Dict[str, Any], "messages": List[str]}``
     """
     outdir.mkdir(parents=True, exist_ok=True)
 
-    log = run_sandbox(apk_path, outdir)
+    hooks = resolve_hooks(enable_hooks, disable_hooks)
+    log, metrics, messages = run_sandbox(apk_path, outdir, hooks=hooks)
     permissions: List[str] = collect_permissions(apk_path)
     network: List[Dict[str, str]] = sniff_network(apk_path)
 
     (outdir / "permissions.json").write_text(json.dumps(permissions, indent=2))
     (outdir / "network.json").write_text(json.dumps(network, indent=2))
+    if metrics:
+        (outdir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    if messages:
+        (outdir / "messages.json").write_text(json.dumps(messages, indent=2))
 
-    return {"log": log, "permissions": permissions, "network": network}
+    return {
+        "log": log,
+        "permissions": permissions,
+        "network": network,
+        "metrics": metrics,
+        "messages": messages,
+    }

--- a/testing/test_sandbox.py
+++ b/testing/test_sandbox.py
@@ -1,11 +1,16 @@
+
 from pathlib import Path
 from sandbox import run_sandbox, collect_permissions, sniff_network, run_analysis
 
 
 def test_run_sandbox(tmp_path: Path):
-    log = run_sandbox("/tmp/app.apk", tmp_path)
+    log, metrics, messages = run_sandbox(
+        "/tmp/app.apk", tmp_path, hooks=["http_logger", "crypto_usage"]
+    )
     assert log.exists()
     assert "app.apk" in log.read_text()
+    assert messages
+    assert metrics["network_endpoints"] == ["http://example.com"]
 
 
 def test_collect_permissions():
@@ -22,5 +27,16 @@ def test_run_analysis(tmp_path: Path):
     result = run_analysis("/tmp/app.apk", tmp_path)
     assert (tmp_path / "permissions.json").exists()
     assert (tmp_path / "network.json").exists()
+    assert (tmp_path / "metrics.json").exists()
+    assert (tmp_path / "messages.json").exists()
     assert result["permissions"]
     assert result["network"]
+    assert result["messages"]
+    assert "NETWORK:http://example.com" in result["messages"]
+    assert result["metrics"]["network_endpoints"] == ["http://example.com"]
+
+
+def test_run_analysis_disable_hook(tmp_path: Path):
+    result = run_analysis("/tmp/app.apk", tmp_path, disable_hooks=["http_logger"])
+    assert "NETWORK:http://example.com" not in result["messages"]
+    assert result["metrics"]["network_endpoints"] == []


### PR DESCRIPTION
## Summary
- auto-discover available Frida hooks and select them via CLI or API
- capture hook messages and runtime metrics in sandbox reports
- add tests for hook configuration and message capture

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f35c05a08327ba9bf485ff83cd9e