### PR TITLE
Add FastAPI scan server and CLI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ python main.py
 ```
 
 Analysis results are written to the `output/` directory.
+
+## API Server
+
+A lightweight REST API can be launched to submit APKs for analysis and
+retrieve risk reports.  Start the server via the CLI:
+
+```bash
+python -m cli.actions serve
+```
+
+This will start a FastAPI application on `localhost:8000` exposing endpoints:
+
+* `POST /scans` – upload an APK and queue analysis
+* `GET /scans/{id}` – check job status and view the latest risk report
+* `GET /scans/{id}/report?format=json|html` – download the generated report

--- a/cli/actions.py
+++ b/cli/actions.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 from contextlib import contextmanager
 from typing import Any, Dict, Optional
+import argparse
 
 from core import display, menu, renderers, config
 from .prompts import prompt_existing_path
@@ -340,3 +341,30 @@ def _display_manifest_insights(outdir: Path) -> None:
         for kind, names in diff.get("removed_components", {}).items():
             if names:
                 print(f"Removed {kind.title()}s: {', '.join(names)}")
+
+
+def run_server(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start the API server using uvicorn."""
+    import uvicorn
+
+    uvicorn.run("server:app", host=host, port=port)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Minimal CLI for auxiliary commands."""
+    parser = argparse.ArgumentParser(description="Rotterdam utilities")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_serve = sub.add_parser("serve", help="start API server")
+    p_serve.add_argument("--host", default="127.0.0.1")
+    p_serve.add_argument("--port", type=int, default=8000)
+
+    args = parser.parse_args(argv)
+    if args.cmd == "serve":
+        run_server(args.host, args.port)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,16 @@
-"""Server package exposing API for device enumeration, job submission, and report retrieval."""
+"""FastAPI application exposing scan submission and report retrieval endpoints."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from orchestrator.worker import start_worker
+
+from .routes import router
+
+# FastAPI application
+app = FastAPI(title="Rotterdam Scanner API")
+app.include_router(router)
+
+# Background worker to process scheduled jobs
+start_worker()

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,0 +1,101 @@
+"""API routes for submitting APK scans and retrieving results."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from orchestrator.scheduler import scheduler
+from risk_reporting import create_risk_report
+from storage.repository import RiskReportRepository
+
+router = APIRouter()
+
+# Repository instance to persist and retrieve risk reports
+_repo = RiskReportRepository()
+
+# Directory for analysis outputs and uploaded files
+_ANALYSIS_ROOT = Path("analysis")
+_ANALYSIS_ROOT.mkdir(exist_ok=True)
+
+
+def _process_apk(apk_path: str) -> dict[str, str]:
+    """Worker job to analyse ``apk_path`` and persist results.
+
+    Returns a mapping with the package name and analysis directory used so that
+    API endpoints can later retrieve reports.
+    """
+    path = Path(apk_path)
+    package_name = path.stem
+
+    # Generate a risk report and persist via the repository
+    result = create_risk_report(package_name, repository=_repo)
+
+    # Write JSON and HTML versions to a unique directory
+    out_dir = _ANALYSIS_ROOT / uuid.uuid4().hex
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = out_dir / "report.json"
+    json_path.write_text(json.dumps(result, indent=2))
+
+    html_path = out_dir / "report.html"
+    html_content = "<html><body><pre>{}</pre></body></html>".format(
+        json.dumps(result, indent=2)
+    )
+    html_path.write_text(html_content)
+
+    return {"package_name": package_name, "analysis_dir": str(out_dir)}
+
+
+@router.post("/scans")
+async def create_scan(file: UploadFile = File(...)) -> dict[str, str]:
+    """Accept an APK upload and queue it for analysis."""
+    uploads_dir = _ANALYSIS_ROOT / "uploads"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+
+    dest = uploads_dir / file.filename
+    with dest.open("wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    job_id = scheduler.submit_job(_process_apk, str(dest))
+    return {"id": job_id}
+
+
+@router.get("/scans/{scan_id}")
+async def get_scan(scan_id: str) -> dict[str, object]:
+    """Return the status of a queued scan and any available risk report."""
+    status = scheduler.job_status(scan_id)
+    report: dict | None = None
+
+    job = scheduler.get_job(scan_id)
+    if status == "completed" and job and job.result:
+        package = job.result.get("package_name")
+        if package:
+            latest = _repo.get_latest(package)
+            report = latest.to_dict() if latest else None
+
+    return {"id": scan_id, "status": status, "report": report}
+
+
+@router.get("/scans/{scan_id}/report")
+async def stream_report(scan_id: str, format: str = "json"):
+    """Stream the JSON or HTML report file for a completed scan."""
+    job = scheduler.get_job(scan_id)
+    if not job or job.status != "completed" or not job.result:
+        raise HTTPException(status_code=404, detail="report not available")
+
+    analysis_dir = job.result.get("analysis_dir")
+    if not analysis_dir:
+        raise HTTPException(status_code=404, detail="report not available")
+
+    path = Path(analysis_dir) / f"report.{format}"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="report not found")
+
+    media_type = "application/json" if format == "json" else "text/html"
+    return FileResponse(path, media_type=media_type, filename=path.name)


### PR DESCRIPTION
## Summary
- Implement FastAPI server with background worker
- Add scan endpoints for uploading APKs, job status, and report streaming
- Provide CLI command to launch server and document usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f355e2bc8327898d67a98ffa211d