### PR TITLE
feat: expand scan API and scheduler maintenance

### DIFF
--- a/tests/test_scan_routes.py
+++ b/tests/test_scan_routes.py
@@ -1,0 +1,59 @@
+"""Tests for scan upload and retrieval endpoints."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from server import app
+from orchestrator.scheduler import scheduler
+
+
+client = TestClient(app)
+
+
+def _wait_for_jobs():
+    scheduler.wait_for_all()
+    for _ in range(50):
+        if all((scheduler.get_job(jid) and scheduler.get_job(jid).status == "completed") for jid in scheduler.list_jobs()):
+            break
+        time.sleep(0.1)
+
+
+def test_upload_filename_sanitized(tmp_path):
+    data = {"file": ("../../evil.apk", b"apkdata", "application/vnd.android.package-archive")}
+    resp = client.post("/scans", files=data)
+    assert resp.status_code == 200
+    scan_id = resp.json()["scan_id"]
+    assert scan_id
+
+    uploads_dir = Path("analysis/uploads")
+    # Ensure file is stored inside uploads directory
+    assert any(p.name.endswith("evil.apk") for p in uploads_dir.iterdir())
+    assert not (uploads_dir / ".." / "evil.apk").exists()
+
+    _wait_for_jobs()
+    # Invalid format should be rejected
+    bad = client.get(f"/scans/{scan_id}/report?format=xml")
+    assert bad.status_code in {400, 404}
+
+
+def test_findings_and_artifacts_endpoints():
+    data = {"file": ("app.apk", b"apkdata", "application/vnd.android.package-archive")}
+    resp = client.post("/scans", files=data)
+    scan_id = resp.json()["scan_id"]
+    _wait_for_jobs()
+
+    res = client.get(f"/scans/{scan_id}/findings")
+    assert res.status_code in {200, 404}
+    if res.status_code == 200:
+        assert isinstance(res.json(), list)
+
+    res = client.get(f"/scans/{scan_id}/artifacts")
+    assert res.status_code in {200, 404}
+    if res.status_code == 200:
+        artifacts = res.json()
+        assert any(a["name"] == "report.json" for a in artifacts)
+

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -1,0 +1,19 @@
+"""Ensure completed jobs are pruned after TTL."""
+
+from __future__ import annotations
+
+import time
+
+from workers.scheduler import Scheduler
+
+
+def test_prune_jobs_removes_old_entries():
+    sched = Scheduler()
+    job_id = sched.submit_job(lambda: None)
+    job = sched.get_job(job_id)
+    assert job is not None
+    # Make job appear old
+    job.created_at -= 7200
+    sched.mark_done(job, None)
+    # Should prune immediately since job is older than default TTL
+    assert sched.get_job(job_id) is None


### PR DESCRIPTION
## Summary
- sanitize uploaded APK names and expose richer scan endpoints
- harden report streaming and align responses around `scan_id`
- add job TTL pruning to scheduler

## Testing
- `pytest tests/test_scan_routes.py tests/test_scheduler_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3fd342eec8327895bb5cef9918fd8