### PR TITLE
Add robust CLI menu framework with JSON mode

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -1,9 +1,18 @@
 """CLI entry point for the Android Tool."""
 from __future__ import annotations
 
+import argparse
+import json
+
 from . import run_main_menu
 
 
 def main() -> None:
-    """Execute the interactive main menu."""
-    run_main_menu()
+    """Execute the main menu."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Output menus as JSON")
+    args = parser.parse_args()
+
+    result = run_main_menu(json_mode=args.json)
+    if args.json and result is not None:
+        print(json.dumps(result))

--- a/cli/actions.py
+++ b/cli/actions.py
@@ -20,6 +20,7 @@ from devices import (
     packages,
     apk,
     processes,
+    selection,
 )
 from analysis import analyze_apk
 from sandbox import run_analysis as sandbox_analyze, compute_runtime_metrics
@@ -123,6 +124,35 @@ def scan_dangerous_permissions(serial: str) -> None:
             print("No apps requesting dangerous permissions found.")
             return
         renderers.print_permission_scan(risky)
+
+
+def scan_for_devices() -> None:
+    """Rescan ADB for devices and display the results."""
+    logger.info("scan_for_devices")
+    try:
+        detailed = selection.refresh_devices()
+    except RuntimeError as e:
+        logger.exception("device scan failed")
+        display.fail(str(e))
+        return
+
+    display.print_section("Scan Results")
+    if not detailed:
+        logger.info("no devices discovered")
+        print("No devices discovered.")
+        return
+
+    renderers.print_basic_device_table(detailed)
+
+
+def export_device_report(serial: str) -> None:
+    """Placeholder for exporting a device report."""
+    display.info("Export device report not implemented yet.")
+
+
+def quick_security_scan(serial: str) -> None:
+    """Placeholder for quick security scan."""
+    display.info("Quick security scan not implemented yet.")
 
 
 def list_running_processes(serial: str) -> None:

--- a/core/display.py
+++ b/core/display.py
@@ -97,6 +97,89 @@ def print_section(title: str, underline: str = "=") -> None:
     print()
 
 
+def render_menu(
+    title: str,
+    options: Sequence[str],
+    exit_label: str = "Back",
+    *,
+    serial: Optional[str] = None,
+) -> str:
+    """Return a framed menu string.
+
+    The menu is rendered inside a simple box using box-drawing characters.
+    ``serial`` can be supplied to show contextual information (e.g. the
+    connected device serial).
+    """
+
+    header = title.strip()
+    if serial:
+        header = f"{header} (serial: {serial})"
+
+    # Determine width based on longest line
+    body = [f"[{i}] {opt}" for i, opt in enumerate(options, start=1)]
+    body.append(f"[0] {exit_label}")
+    width = max(len(header), *(len(line) for line in body)) + 4
+
+    top = "╭" + "─" * (width - 2) + "╮"
+    sep = "├" + "─" * (width - 2) + "┤"
+    bottom = "╰" + "─" * (width - 2) + "╯"
+
+    lines = [top, f"│ {header.ljust(width - 4)} │", sep]
+    for line in body:
+        lines.append(f"│ {line.ljust(width - 4)} │")
+    lines.append(bottom)
+    return "\n".join(lines)
+
+
+def print_menu(title: str, options: Sequence[str], exit_label: str = "Exit") -> None:
+    """Convenience wrapper around :func:`render_menu` that prints the menu."""
+    print(render_menu(title, options, exit_label))
+
+
+def prompt_choice(
+    valid_options: Iterable[str],
+    default: Optional[str] = None,
+    message: str = "Select an option",
+) -> str:
+    """Prompt the user until a valid option is entered.
+
+    Parameters
+    ----------
+    valid_options:
+        Iterable of accepted string choices.
+    default:
+        Value returned when the user presses Enter without input.
+
+    Returns
+    -------
+    str
+        The chosen option. ``"q"`` is returned if the user requests to quit
+        via ``q``/``Q`` or triggers EOF/KeyboardInterrupt.
+    """
+
+    options = {str(opt) for opt in valid_options}
+
+    while True:
+        try:
+            raw = input(f"{message}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return "q"
+
+        if not raw:
+            if default is not None:
+                return default
+            warn("Invalid choice. Please try again.")
+            continue
+
+        if raw.lower() == "q":
+            return "q"
+
+        if raw in options:
+            return raw
+
+        warn("Invalid choice. Please try again.")
+
+
 # -----------------------------
 # Simple text helpers
 # -----------------------------

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 """Top-level entry point for the Android Tool CLI."""
 from __future__ import annotations
 
+import argparse
+import json
+
 from cli import run_main_menu
 from logging_config import get_logger
 
@@ -8,10 +11,16 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
-    """Run the interactive CLI menu."""
-    logger.info("Launching CLI")
-    run_main_menu()
+    """Run the CLI menu."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Output menus as JSON")
+    args = parser.parse_args()
+
+    logger.info("Launching CLI", extra={"json": args.json})
+    result = run_main_menu(json_mode=args.json)
+    if args.json and result is not None:
+        print(json.dumps(result))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - script entry
     main()

--- a/tests/test_cli_menus.py
+++ b/tests/test_cli_menus.py
@@ -1,0 +1,44 @@
+import builtins
+
+import pytest
+
+from core import display
+from cli import menu as cli_menu
+
+
+def test_render_menu_formatting():
+    out = display.render_menu(
+        "Device Menu",
+        ["Option A", "Option B"],
+        exit_label="Back",
+        serial="XYZ",
+    )
+    assert "Device Menu (serial: XYZ)" in out
+    assert "[1] Option A" in out
+    assert out.splitlines()[0].startswith("╭")
+
+
+def test_prompt_choice_loop(monkeypatch, capsys):
+    inputs = iter(["abc", "99", "2"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+    choice = display.prompt_choice({"1", "2"})
+    assert choice == "2"
+    assert "Invalid choice" in capsys.readouterr().err
+
+
+def test_prompt_choice_quit(monkeypatch):
+    monkeypatch.setattr(builtins, "input", lambda _: "q")
+    assert display.prompt_choice({"1"}) == "q"
+
+
+def test_device_menu_offline(monkeypatch, capsys):
+    monkeypatch.setattr(cli_menu, "device_online", lambda serial: False)
+    cli_menu.run_device_menu("abc")
+    assert "no longer online" in capsys.readouterr().err.lower()
+
+
+def test_main_menu_json():
+    data = cli_menu.run_main_menu(json_mode=True)
+    assert data["title"] == "Main Menu"
+    assert any(opt["label"] == "Check for connected devices" for opt in data["options"])
+


### PR DESCRIPTION
## Summary
- replace menu rendering with framed, context-aware layout and shared prompt helper
- cache device listings and expose rescan, report, and scan placeholders in CLI menus
- add JSON output mode for main and device menus with --json entrypoint flag
- refine device submenu to core actions with liveness checks and streamline main menu via shared renderer

## Testing
- `python -m py_compile core/display.py core/menu.py cli/menu.py cli/actions.py platform/android/devices/selection.py main.py cli/__main__.py tests/test_cli_menus.py`
- `pytest tests/test_cli_menus.py -q`
- `pytest -q` *(fails: /root/.pyenv/versions/3.12.10/lib/libyara.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1bca9d08327a90a125c56469a1a