### PR TITLE
Add class-based session-aware logging across CLI

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -1,7 +1,14 @@
 """CLI entry point for the Android Tool."""
 from __future__ import annotations
 
+import uuid
+
 from . import run_main_menu
+from logging_config import StructuredLogger
+
+# Generate a session identifier for this CLI invocation
+SESSION_ID = str(uuid.uuid4())
+StructuredLogger.set_session_id(SESSION_ID)
 
 
 def main() -> None:

--- a/cli/actions.py
+++ b/cli/actions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from contextlib import contextmanager
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 import argparse
 
 from core import display, menu, renderers, config
@@ -27,8 +27,10 @@ from sandbox import ui_driver
 
 # Optional logging integration
 try:
-    from logging_config import get_logger, log_context  # type: ignore
-    logger = get_logger(__name__)  # type: ignore
+    from logging_config import StructuredLogger  # type: ignore
+
+    logger = StructuredLogger.get_logger(__name__)  # type: ignore
+    log_context = StructuredLogger.context  # type: ignore
 except Exception:  # pragma: no cover
     import logging
 
@@ -45,50 +47,68 @@ except Exception:  # pragma: no cover
         yield
 
 
+@contextmanager
+def _action_context(
+    action: str,
+    *,
+    device_serial: str | None = None,
+    apk_path: str | None = None,
+):
+    """Wrapper around :func:`log_context` to reduce repetition in actions."""
+    with log_context(
+        device_serial=device_serial,
+        action=action,
+        apk_path=apk_path,
+    ):
+        yield
+
+
 def show_connected_devices() -> None:
     """List connected devices using basic ``adb devices`` output."""
-    logger.info("show_connected_devices")
-    try:
-        output = discovery.check_connected_devices()
-        devs = discovery.parse_devices_l(output)  # keep API as defined in devices.discovery
-    except RuntimeError as e:
-        logger.exception("failed to check connected devices")
-        display.fail(str(e))
-        return
+    with _action_context("show_connected_devices"):
+        logger.info("show_connected_devices")
+        try:
+            output = discovery.check_connected_devices()
+            devs = discovery.parse_devices_l(output)  # keep API as defined in devices.discovery
+        except RuntimeError as e:
+            logger.exception("failed to check connected devices")
+            display.fail(str(e))
+            return
 
-    display.print_section("ADB Devices")
-    if not devs:
-        logger.info("no devices attached")
-        print("No devices attached.")
-        return
+        display.print_section("ADB Devices")
+        if not devs:
+            logger.info("no devices attached")
+            print("No devices attached.")
+            return
 
-    renderers.print_basic_device_table(devs)
+        renderers.print_basic_device_table(devs)
 
 
 def show_detailed_devices() -> None:
     """List devices with manufacturer and OS details."""
-    logger.info("show_detailed_devices")
-    try:
-        detailed = discovery.list_detailed_devices()
-    except RuntimeError as e:
-        logger.exception("failed to list detailed devices")
-        display.fail(str(e))
-        return
+    with _action_context("show_detailed_devices"):
+        logger.info("show_detailed_devices")
+        try:
+            detailed = discovery.list_detailed_devices()
+        except RuntimeError as e:
+            logger.exception("failed to list detailed devices")
+            display.fail(str(e))
+            return
 
-    if not detailed:
-        logger.info("no devices attached")
-        display.print_section("Connected Devices (Detailed)")
-        print("No devices attached.")
-        return
+        if not detailed:
+            logger.info("no devices attached")
+            display.print_section("Connected Devices (Detailed)")
+            print("No devices attached.")
+            return
 
-    report = ieee.format_device_inventory(detailed)
-    logger.info("found %d devices", len(detailed))
-    print(report)
+        report = ieee.format_device_inventory(detailed)
+        logger.info("found %d devices", len(detailed))
+        print(report)
 
 
 def list_installed_packages(serial: str) -> None:
     """Display packages installed on the device."""
-    with log_context(device=serial):
+    with _action_context("list_installed_packages", device_serial=serial):
         logger.info("list_installed_packages")
         try:
             pkg_info = packages.inventory_packages(serial)
@@ -108,7 +128,7 @@ def list_installed_packages(serial: str) -> None:
 
 def scan_dangerous_permissions(serial: str) -> None:
     """Scan packages for dangerous permissions and display results."""
-    with log_context(device=serial):
+    with _action_context("scan_dangerous_permissions", device_serial=serial):
         logger.info("scan_dangerous_permissions")
         try:
             risky = packages.scan_for_dangerous_permissions(serial)
@@ -127,7 +147,7 @@ def scan_dangerous_permissions(serial: str) -> None:
 
 def list_running_processes(serial: str) -> None:
     """List running processes on the device."""
-    with log_context(device=serial):
+    with _action_context("list_running_processes", device_serial=serial):
         logger.info("list_running_processes")
         try:
             procs = processes.list_processes(serial)
@@ -153,8 +173,7 @@ def analyze_apk_path() -> None:
     if not apk_path:
         return
 
-    app_name = Path(apk_path).stem
-    with log_context(app=app_name):
+    with _action_context("analyze_apk_path", apk_path=apk_path):
         logger.info("analyze_apk_path", extra={"apk": apk_path})
         try:
             out = analyze_apk(apk_path)
@@ -169,7 +188,7 @@ def analyze_apk_path() -> None:
 
 def analyze_installed_app(serial: str) -> None:
     """Select an installed app, pull its APK, and run static analysis."""
-    with log_context(device=serial):
+    with _action_context("analyze_installed_app", device_serial=serial):
         logger.info("analyze_installed_app")
         try:
             pkgs = packages.list_installed_packages(serial)
@@ -198,27 +217,30 @@ def analyze_installed_app(serial: str) -> None:
             return
         package = options[choice - 1][1]
 
-        with log_context(app=package):
-            try:
-                evidence = apk.acquire_apk(
-                    serial, package, dest_dir=f"output/{package}"
-                )
-                logger.info("apk extracted", extra={"output": f"output/{package}"})
-                print("Status: Application package extracted successfully.")
-                out = analyze_apk(
-                    str(evidence["artifact"]), outdir=f"output/{package}"
-                )
-            except Exception as e:  # pragma: no cover
-                logger.exception("analysis failed")
-                display.fail(f"Analysis failed: {e}")
-                return
-            logger.info("analysis completed", extra={"report": str(out / 'report.json')})
-            print(
-                f"Status: Static analysis completed. Report at {out / 'report.json'}"
+        try:
+            evidence = apk.acquire_apk(
+                serial, package, dest_dir=f"output/{package}"
             )
-            _display_manifest_insights(out)
-            log = ieee.format_evidence_log([evidence])
-            print(log)
+            apk_path = str(evidence["artifact"])
+            logger.info("apk extracted", extra={"output": f"output/{package}"})
+            print("Status: Application package extracted successfully.")
+            with _action_context(
+                "analyze_installed_app",
+                device_serial=serial,
+                apk_path=apk_path,
+            ):
+                out = analyze_apk(apk_path, outdir=f"output/{package}")
+        except Exception as e:  # pragma: no cover
+            logger.exception("analysis failed")
+            display.fail(f"Analysis failed: {e}")
+            return
+        logger.info("analysis completed", extra={"report": str(out / 'report.json')})
+        print(
+            f"Status: Static analysis completed. Report at {out / 'report.json'}"
+        )
+        _display_manifest_insights(out)
+        log = ieee.format_evidence_log([evidence])
+        print(log)
 
 
 def sandbox_analyze_apk() -> None:
@@ -232,7 +254,7 @@ def sandbox_analyze_apk() -> None:
 
     app_name = Path(apk_path).stem
     outdir = config.OUTPUT_DIR / f"{app_name}_sandbox"
-    with log_context(app=app_name):
+    with _action_context("sandbox_analyze_apk", apk_path=apk_path):
         logger.info("sandbox_analyze_apk", extra={"apk": apk_path})
         try:
             results = sandbox_analyze(apk_path, outdir)
@@ -259,36 +281,37 @@ def sandbox_analyze_apk() -> None:
 
 def explore_installed_app(serial: str) -> None:
     """Select an installed package and run automated UI exploration."""
-    try:
-        pkgs = packages.list_installed_packages(serial)
-    except RuntimeError as e:
-        display.fail(str(e))
-        return
-    if not pkgs:
-        print("Status: No packages found.")
-        return
+    with _action_context("explore_installed_app", device_serial=serial):
+        try:
+            pkgs = packages.list_installed_packages(serial)
+        except RuntimeError as e:
+            display.fail(str(e))
+            return
+        if not pkgs:
+            print("Status: No packages found.")
+            return
 
-    choice = menu.show_menu(
-        "Installed Packages",
-        pkgs,
-        exit_label="Cancel",
-        prompt="Select package",
-    )
-    if choice == 0:
-        print("Status: No package selected.")
-        return
+        choice = menu.show_menu(
+            "Installed Packages",
+            pkgs,
+            exit_label="Cancel",
+            prompt="Select package",
+        )
+        if choice == 0:
+            print("Status: No package selected.")
+            return
 
-    package = pkgs[choice - 1]
-    activities = ui_driver.run_monkey(serial, package)
-    metrics = compute_runtime_metrics([], [], [], activities)
+        package = pkgs[choice - 1]
+        activities = ui_driver.run_monkey(serial, package)
+        metrics = compute_runtime_metrics([], [], [], activities)
 
-    display.print_section("Visited Activities")
-    if metrics.get("activities"):
-        for act in metrics["activities"]:
-            print(act)
-        print(f"Total: {metrics['activity_count']}")
-    else:
-        print("No activity coverage recorded.")
+        display.print_section("Visited Activities")
+        if metrics.get("activities"):
+            for act in metrics["activities"]:
+                print(act)
+            print(f"Total: {metrics['activity_count']}")
+        else:
+            print("No activity coverage recorded.")
 
 
 def _display_manifest_insights(outdir: Path) -> None:
@@ -347,7 +370,8 @@ def run_server(host: str = "127.0.0.1", port: int = 8000) -> None:
     """Start the API server using uvicorn."""
     import uvicorn
 
-    uvicorn.run("server:app", host=host, port=port)
+    with _action_context("run_server"):
+        uvicorn.run("server:app", host=host, port=port)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,73 +1,132 @@
 import json
 import logging
-from logging.handlers import RotatingFileHandler
-from pathlib import Path
 from contextlib import contextmanager
 import contextvars
-
-# Context variables for device and app metadata
-_device_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("device", default=None)
-_app_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("app", default=None)
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON including context metadata."""
+class StructuredLogger:
+    """Central logging utility providing JSON logs with contextual fields."""
 
-    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
-        log_record = {
-            "time": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "module": record.name,
-            "message": record.getMessage(),
-        }
-        device = _device_var.get()
-        app = _app_var.get()
-        if device:
-            log_record["device"] = device
-        if app:
-            log_record["app"] = app
-        if record.exc_info:
-            log_record["exc_info"] = self.formatException(record.exc_info)
-        return json.dumps(log_record)
-
-
-def _build_handler() -> logging.Handler:
-    """Create a rotating file handler writing to reports/logs/audit.log."""
-    log_dir = Path(__file__).resolve().parent / "reports" / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    file_handler = RotatingFileHandler(
-        log_dir / "audit.log", maxBytes=1_000_000, backupCount=5
+    _session_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "session_id", default=None
     )
-    stream_handler = logging.StreamHandler()
+    _device_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "device_serial", default=None
+    )
+    _action_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "action", default=None
+    )
+    _apk_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "apk_path", default=None
+    )
 
-    formatter = JsonFormatter()
-    file_handler.setFormatter(formatter)
-    stream_handler.setFormatter(formatter)
+    _configured: bool = False
 
-    root = logging.getLogger()
-    root.setLevel(logging.INFO)
-    root.addHandler(file_handler)
-    root.addHandler(stream_handler)
-    return root
+    class _JsonFormatter(logging.Formatter):
+        """Format log records as JSON including contextual metadata."""
+
+        def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
+            log_record = {
+                "time": self.formatTime(record, self.datefmt),
+                "level": record.levelname,
+                "module": record.name,
+                "message": record.getMessage(),
+            }
+            session_id = StructuredLogger._session_var.get()
+            device = StructuredLogger._device_var.get()
+            action = StructuredLogger._action_var.get()
+            apk = StructuredLogger._apk_var.get()
+            if session_id:
+                log_record["session_id"] = session_id
+            if device:
+                log_record["device_serial"] = device
+            if action:
+                log_record["action"] = action
+            if apk:
+                log_record["apk_path"] = apk
+            if record.exc_info:
+                log_record["exc_info"] = self.formatException(record.exc_info)
+            return json.dumps(log_record)
+
+    @classmethod
+    def _configure(cls) -> None:
+        """Set up root logger with JSON formatting if not already configured."""
+        if cls._configured:
+            return
+
+        log_dir = Path(__file__).resolve().parent / "reports" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_dir / "audit.log", maxBytes=1_000_000, backupCount=5
+        )
+        stream_handler = logging.StreamHandler()
+        formatter = cls._JsonFormatter()
+        file_handler.setFormatter(formatter)
+        stream_handler.setFormatter(formatter)
+
+        root = logging.getLogger()
+        root.setLevel(logging.INFO)
+        root.addHandler(file_handler)
+        root.addHandler(stream_handler)
+        cls._configured = True
+
+    @classmethod
+    def get_logger(cls, name: str | None = None) -> logging.Logger:
+        """Return a configured logger with JSON formatting."""
+        cls._configure()
+        return logging.getLogger(name)
+
+    @classmethod
+    def set_session_id(cls, session_id: str) -> None:
+        """Bind a session identifier for all subsequent log records."""
+        cls._session_var.set(session_id)
+
+    @classmethod
+    @contextmanager
+    def context(
+        cls,
+        *,
+        device_serial: str | None = None,
+        action: str | None = None,
+        apk_path: str | None = None,
+    ):
+        """Inject contextual fields into log records within the ``with`` block."""
+
+        tokens: list[tuple[contextvars.ContextVar[str | None], contextvars.Token[str | None]]] = []
+        if device_serial is not None:
+            tokens.append((cls._device_var, cls._device_var.set(device_serial)))
+        if action is not None:
+            tokens.append((cls._action_var, cls._action_var.set(action)))
+        if apk_path is not None:
+            tokens.append((cls._apk_var, cls._apk_var.set(apk_path)))
+        try:
+            yield
+        finally:
+            for var, token in reversed(tokens):
+                var.reset(token)
 
 
-_root_logger: logging.Logger = _build_handler()
-
-
+# Backwards compatibility helpers
 def get_logger(name: str | None = None) -> logging.Logger:
-    """Return a configured logger with JSON formatting."""
-    return logging.getLogger(name)
+    """Return a structured logger (legacy helper)."""
+    return StructuredLogger.get_logger(name)
 
 
 @contextmanager
-def log_context(*, device: str | None = None, app: str | None = None):
-    """Context manager to inject device/app metadata into log records."""
-    token_dev = _device_var.set(device) if device is not None else None
-    token_app = _app_var.set(app) if app is not None else None
-    try:
+def log_context(
+    *,
+    session_id: str | None = None,
+    device_serial: str | None = None,
+    action: str | None = None,
+    apk_path: str | None = None,
+):
+    """Legacy wrapper dispatching to :class:`StructuredLogger`."""
+
+    if session_id is not None:
+        StructuredLogger.set_session_id(session_id)
+    with StructuredLogger.context(
+        device_serial=device_serial, action=action, apk_path=apk_path
+    ):
         yield
-    finally:
-        if token_dev is not None:
-            _device_var.reset(token_dev)
-        if token_app is not None:
-            _app_var.reset(token_app)

--- a/platform/android/analysis/dynamic/permission_monitor.py
+++ b/platform/android/analysis/dynamic/permission_monitor.py
@@ -17,9 +17,9 @@ from datetime import datetime, timezone
 from typing import DefaultDict, Dict, Iterable, List
 
 from devices import adb
-from logging_config import get_logger, log_context
+from logging_config import StructuredLogger
 
-logger = get_logger(__name__)
+logger = StructuredLogger.get_logger(__name__)
 
 
 def _run_shell(cmd: list[str]) -> str:
@@ -76,7 +76,7 @@ class PermissionMonitor:
             comp = match.group("comp")
             timestamp = datetime.now(tz=timezone.utc).isoformat()
             access = PermissionAccess(timestamp, perm, comp)
-            with log_context(app=self.package):
+            with StructuredLogger.context(action="permission_monitor", apk_path=self.package):
                 logger.info("%s | %s accessed by %s", timestamp, perm, comp)
             self._summary[perm] += 1
             self._logs.append(access)


### PR DESCRIPTION
## Summary
- centralize structured JSON logging through new `StructuredLogger` class
- bind a unique session ID at CLI startup
- use logger context helper in CLI actions and permission monitor for device, action and APK metadata

## Testing
- `pytest` *(fails: /root/.pyenv/versions/3.12.10/lib/libyara.so: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1c35c7c8327a6efd3dda69b298f