### PR TITLE
Add database status CLI action and menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ python main.py
 
 Analysis results are written to the `output/` directory.
 
+### Database status
+
+The interactive menu provides a **Database** option that performs a
+connectivity check, reports table counts and lists the most recent analyses.
+This helps surface misconfiguration or missing tables early during
+development.
+
 ## API Server
 
 A lightweight REST API can be launched to submit APKs for analysis and

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -33,6 +33,7 @@ def run_main_menu() -> None:
         "List installed packages on selected device",
         "Scan installed apps for dangerous permissions",
         "List running processes on selected device",
+        "Database",  # check connectivity and recent analyses
         "Analyze a local APK for permissions and secrets",
         "Pull and analyze an installed app",
         "Sandbox analyze a local APK",
@@ -63,14 +64,16 @@ def run_main_menu() -> None:
             if selected_serial:
                 actions.list_running_processes(selected_serial)
         elif choice == 7:
-            actions.analyze_apk_path()
+            actions.show_database_status()
         elif choice == 8:
+            actions.analyze_apk_path()
+        elif choice == 9:
             selected_serial = _ensure_device_selected(selected_serial)
             if selected_serial:
                 actions.analyze_installed_app(selected_serial)
-        elif choice == 9:
-            actions.sandbox_analyze_apk()
         elif choice == 10:
+            actions.sandbox_analyze_apk()
+        elif choice == 11:
             selected_serial = _ensure_device_selected(selected_serial)
             if selected_serial:
                 actions.explore_installed_app(selected_serial)


### PR DESCRIPTION
## Summary
- expand database status helper with table-count utilities and recent-analysis query
- warn about missing tables to surface schema issues early
- document database option in CLI menu and README

## Testing
- `pytest` *(fails: OSError: libyara.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1c22bc8832786965104c4342681