### PR TITLE
feat(cli): launch web UI from menu

### DIFF
--- a/cli/actions.py
+++ b/cli/actions.py
@@ -343,6 +343,37 @@ def _display_manifest_insights(outdir: Path) -> None:
                 print(f"Removed {kind.title()}s: {', '.join(names)}")
 
 
+def launch_web_app(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Launch the web interface, starting the server if needed."""
+    import socket
+    import threading
+    import time
+    import webbrowser
+    import uvicorn
+
+    logger.info("launch_web_app", extra={"host": host, "port": port})
+
+    def _port_open() -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.connect((host, port))
+                return True
+            except OSError:
+                return False
+
+    if not _port_open():
+        thread = threading.Thread(
+            target=uvicorn.run,
+            args=("server:app",),
+            kwargs={"host": host, "port": port},
+            daemon=True,
+        )
+        thread.start()
+        time.sleep(0.5)
+
+    webbrowser.open(f"http://{host}:{port}")
+
+
 def run_server(host: str = "127.0.0.1", port: int = 8000) -> None:
     """Start the API server using uvicorn."""
     import uvicorn

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -37,6 +37,7 @@ def run_main_menu() -> None:
         "Pull and analyze an installed app",
         "Sandbox analyze a local APK",
         "Explore installed app UI",
+        "Launch web app",
     ]
 
     class _RefreshMenu(Exception):
@@ -74,6 +75,8 @@ def run_main_menu() -> None:
             selected_serial = _ensure_device_selected(selected_serial)
             if selected_serial:
                 actions.explore_installed_app(selected_serial)
+        elif choice == 11:
+            actions.launch_web_app()
         else:
             display.warn(f"Unhandled choice: {choice}")
         raise _RefreshMenu


### PR DESCRIPTION
## Summary
- start uvicorn server in background and open browser via new `launch_web_app`
- expose web app launcher option in CLI main menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4c1c03d748327abf0ead25533450e