### PR TITLE
Add mysql connector and YARA bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Rotterdam is a toolkit for analyzing Android applications and devices. It provid
 ## Development
 
 Set up a Python environment and install the project's dependencies.
+Dependencies are listed in `requirements.txt`, including the MySQL driver
+`mysql-connector-python` and YARA bindings via `yara-python`.
+The YARA wrapper requires the system `libyara` library; on Debian-based
+systems it can be installed with `apt-get install libyara-dev`.
 
 ### Database configuration
 
@@ -14,7 +18,7 @@ connection in one of two ways:
 
 1. Provide a full SQLAlchemy URL via ``DATABASE_URL``::
 
-   ``export DATABASE_URL="mysql+pymysql://user:pass@host/db"``
+   ``export DATABASE_URL="mysql+mysqlconnector://user:pass@host/db"``
 
 2. Set individual MySQL parameters and they will be assembled into a URL::
 

--- a/core/config.py
+++ b/core/config.py
@@ -138,7 +138,7 @@ def get_database_url() -> str:
         host = os.getenv("DB_HOST", "localhost")
         port = os.getenv("DB_PORT", "3306")
         auth = f":{password}" if password else ""
-        return f"mysql+pymysql://{user}{auth}@{host}:{port}/{name}"
+        return f"mysql+mysqlconnector://{user}{auth}@{host}:{port}/{name}"
 
     return "sqlite:///:memory:"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography==45.0.6
 fastapi==0.116.1
 httpx==0.28.1
 jmespath==1.0.1
+mysql-connector-python>=9.0.0
 pydantic==2.11.7
 pytest==8.4.1
 pytest-cov==6.2.1
@@ -13,4 +14,4 @@ scapy==2.6.1
 SQLAlchemy==2.0.43
 starlette==0.47.2
 uvicorn==0.35.0
-yara==1.7.7
+yara-python>=4.5.0

--- a/sandbox/permission_monitor.py
+++ b/sandbox/permission_monitor.py
@@ -1,1 +1,38 @@
-from rotterdam.android.analysis.dynamic.permission_monitor import *  # noqa
+"""Facade for permission monitoring utilities.
+
+This module wraps select helpers from
+:mod:`rotterdam.android.analysis.dynamic.permission_monitor` so that tests can
+patch internal helpers like :func:`_run_shell`.
+"""
+from __future__ import annotations
+
+import rotterdam.android.analysis.dynamic.permission_monitor as _impl
+from rotterdam.android.analysis.dynamic.permission_monitor import PermissionAccess
+
+
+def _run_shell(cmd: list[str]) -> str:
+    """Delegate to the underlying implementation's shell runner."""
+    return _impl._run_shell(cmd)
+
+
+class PermissionMonitor(_impl.PermissionMonitor):
+    """Proxy that routes shell calls through this module for easy patching."""
+
+    def poll(self) -> None:  # type: ignore[override]
+        if self.use_dumpsys:
+            cmd = ["dumpsys", "appops"]
+        else:
+            cmd = ["appops", "get"]
+            if self.package:
+                cmd.append(self.package)
+        output = _run_shell(cmd)
+        self._parse_output(output)
+
+
+def collect_permissions(apk_path: str) -> list[str]:
+    """Return a list of permissions requested by ``apk_path``."""
+    return _impl.collect_permissions(apk_path)
+
+
+__all__ = ["collect_permissions", "PermissionMonitor", "PermissionAccess", "_run_shell"]
+

--- a/tests/test_yara_scan.py
+++ b/tests/test_yara_scan.py
@@ -1,11 +1,16 @@
-import pytest
-import pytest
 from pathlib import Path
+
+import pytest
 
 from analysis.yara_scan import compile_rules, scan_directory
 
 
-yara = pytest.importorskip("yara")
+try:  # pragma: no cover - depends on optional system library
+    import yara  # type: ignore
+except Exception:  # noqa: F401 - the variable is used in pytestmark below
+    yara = None
+
+pytestmark = pytest.mark.skipif(yara is None, reason="yara library not available")
 
 
 def test_scan_directory(tmp_path: Path):

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from .scheduler import scheduler, Job
+from .scheduler import Job
+from orchestrator import scheduler as scheduler_module
 
 
 def worker_loop() -> None:
     """Continuously pull jobs from the scheduler and execute them."""
     while True:
-        job: Job = scheduler.get_next_job()
+        sched = scheduler_module.scheduler
+        job: Job = sched.get_next_job()
         try:
-            scheduler.mark_running(job)
+            sched.mark_running(job)
             result = job.func(*job.args, **job.kwargs)
-            scheduler.mark_done(job, result)
+            sched.mark_done(job, result)
         except Exception as exc:  # pragma: no cover - simple error capture
-            scheduler.mark_failed(job, exc)
+            sched.mark_failed(job, exc)
 
 
 def start_worker(daemon: bool = True) -> None:


### PR DESCRIPTION
## Summary
- document `yara-python` and `mysql-connector-python` as dependencies
- expose a permission monitor facade that is easy to mock in tests
- ensure worker threads use the orchestrator's scheduler
- note the need for the system `libyara` library and skip YARA tests if it's missing

## Testing
- `pytest tests/test_permission_monitor.py -q --no-cov`
- `pytest tests/test_job_queue.py -q --no-cov` *(hangs: no tests ran)*
- `pytest tests/test_yara_scan.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1bf81fc8327b1f0ca5f2195b936