### PR TITLE
Add ML risk classifier and sandbox isolation

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -80,3 +80,11 @@ except Exception:  # pragma: no cover - missing dependencies
     analyze_certificates = None  # type: ignore[assignment]
 else:
     __all__.append("analyze_certificates")
+
+# Optional: simple machine learning classifier
+try:
+    from .ml_model import predict_malicious  # type: ignore[import-not-found]
+except Exception:
+    predict_malicious = None  # type: ignore[assignment]
+else:
+    __all__.append("predict_malicious")

--- a/analysis/ml_model.py
+++ b/analysis/ml_model.py
@@ -1,0 +1,17 @@
+"""Convenience wrapper for the Android static analysis ML model.
+
+This module re-exports :func:`predict_malicious` so callers can simply
+``from analysis.ml_model import predict_malicious`` without needing to know
+the underlying package layout.  If the platform-specific implementation is
+unavailable we raise a helpful runtime error when the function is invoked.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - defensive import
+    from rotterdam.android.analysis.static.ml_model import predict_malicious
+except Exception as exc:  # pragma: no cover - missing platform module
+    def predict_malicious(*args: object, **kwargs: object):  # type: ignore[override]
+        raise RuntimeError("ML model unavailable") from exc
+
+__all__ = ["predict_malicious"]

--- a/platform/android/analysis/static/ml_baseline.json
+++ b/platform/android/analysis/static/ml_baseline.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "benign",
+    "metrics": {"permission_density": 0.1, "component_exposure": 0.1, "cleartext_traffic_permitted": 0}
+  },
+  {
+    "label": "benign",
+    "metrics": {"permission_density": 0.2, "component_exposure": 0.2, "cleartext_traffic_permitted": 0}
+  },
+  {
+    "label": "benign",
+    "metrics": {"permission_density": 0.05, "component_exposure": 0.05, "cleartext_traffic_permitted": 0}
+  },
+  {
+    "label": "malicious",
+    "metrics": {"permission_density": 0.9, "component_exposure": 0.8, "cleartext_traffic_permitted": 1}
+  },
+  {
+    "label": "malicious",
+    "metrics": {"permission_density": 0.85, "component_exposure": 0.95, "cleartext_traffic_permitted": 1}
+  }
+]

--- a/platform/android/analysis/static/ml_model.py
+++ b/platform/android/analysis/static/ml_model.py
@@ -1,0 +1,108 @@
+"""K-nearest neighbour classifier for risk prediction.
+
+This lightweight model demonstrates a simple machine learning component
+for classifying apps as benign or malicious based on derived metrics.
+The training data lives alongside this module in ``ml_baseline.json`` and
+contains a handful of labelled examples.  During prediction we measure the
+Euclidean distance between the input metrics and each training sample,
+select the *k* closest neighbours and return the majority label along with
+basic confidence information.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Any, List, Tuple
+
+_BASELINE_PATH = Path(__file__).with_name("ml_baseline.json")
+_LOG = logging.getLogger(__name__)
+
+
+def _load_baseline() -> List[Tuple[Dict[str, float], str]]:
+    """Return training samples loaded from ``ml_baseline.json``.
+
+    Any failure to load or parse the baseline is logged and results in an
+    empty training set so callers can decide how to handle the absence of
+    model data.
+    """
+
+    try:
+        data = json.loads(_BASELINE_PATH.read_text())
+    except FileNotFoundError:
+        _LOG.warning("ML baseline not found: %s", _BASELINE_PATH)
+        return []
+    except json.JSONDecodeError as e:  # pragma: no cover - invalid baseline
+        _LOG.warning("Invalid ML baseline JSON: %s", e)
+        return []
+
+    return [(entry["metrics"], entry["label"]) for entry in data]
+
+
+_BASELINE = _load_baseline()
+
+
+def _distance(a: Dict[str, float], b: Dict[str, float]) -> float:
+    keys = set(a) | set(b)
+    return sum((a.get(k, 0.0) - b.get(k, 0.0)) ** 2 for k in keys) ** 0.5
+
+
+def _validate_metrics(metrics: Dict[str, Any]) -> Dict[str, float]:
+    """Ensure all metric values are numeric within [0, 1]."""
+    clean: Dict[str, float] = {}
+    for name, value in metrics.items():
+        if not isinstance(value, (int, float)):
+            raise ValueError(f"Metric {name}={value!r} must be numeric")
+        value = float(value)
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(f"Metric {name}={value!r} outside [0,1]")
+        clean[name] = value
+    return clean
+
+
+def predict_malicious(metrics: Dict[str, float], k: int = 3) -> Dict[str, Any]:
+    """Return KNN-based malicious prediction for ``metrics``.
+
+    Parameters
+    ----------
+    metrics:
+        Mapping of feature name to value in the range [0, 1].
+    k:
+        Number of neighbours to consider.  Defaults to 3.
+
+    Returns
+    -------
+    dict
+        ``{"label": str, "confidence": float, "neighbors": list}``
+    """
+    if not _BASELINE:
+        raise RuntimeError("No baseline training data available")
+
+    metrics = _validate_metrics(metrics)
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    neighbours = sorted(
+        ((_distance(metrics, m), label) for m, label in _BASELINE),
+        key=lambda x: x[0],
+    )[:k]
+
+    effective_k = len(neighbours)
+    benign = sum(1 for _, label in neighbours if label == "benign")
+    malicious = effective_k - benign
+    label = "malicious" if malicious > benign else "benign"
+    confidence = (
+        round((malicious if label == "malicious" else benign) / effective_k, 2)
+        if effective_k
+        else 0.0
+    )
+    return {
+        "label": label,
+        "confidence": confidence,
+        "neighbors": [
+            {"distance": round(dist, 3), "label": lbl} for dist, lbl in neighbours
+        ],
+    }
+
+__all__ = ["predict_malicious"]

--- a/platform/android/analysis/static/scoring/risk_score.py
+++ b/platform/android/analysis/static/scoring/risk_score.py
@@ -41,6 +41,7 @@ DEFAULT_WEIGHTS: Dict[str, float] = {
     "malicious_endpoint_count": 0.09,
     "vulnerable_dependency_count": 0.10,
     "untrusted_signature": 0.05,
+    "ml_pred_malicious": 0.05,
     # Network security flags
     "cleartext_traffic_permitted": 0.04,
     "missing_certificate_pinning": 0.03,

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -1,0 +1,16 @@
+import pytest
+
+from analysis.ml_model import predict_malicious
+
+
+def test_predict_malicious_flags_high_risk():
+    metrics = {"permission_density": 0.9, "component_exposure": 0.85, "cleartext_traffic_permitted": 1}
+    result = predict_malicious(metrics)
+    assert result["label"] == "malicious"
+    assert 0 <= result["confidence"] <= 1
+    assert result["neighbors"]
+
+
+def test_predict_malicious_rejects_invalid_metrics():
+    with pytest.raises(ValueError):
+        predict_malicious({"permission_density": 1.5})

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -4,8 +4,10 @@ from sandbox import run_sandbox, collect_permissions, sniff_network, run_analysi
 
 
 def test_run_sandbox(tmp_path: Path):
+    apk = tmp_path / "app.apk"
+    apk.write_text("fake")
     log, metrics, messages = run_sandbox(
-        "/tmp/app.apk", tmp_path, hooks=["http_logger", "crypto_usage"]
+        str(apk), tmp_path, hooks=["http_logger", "crypto_usage"]
     )
     assert log.exists()
     assert "app.apk" in log.read_text()
@@ -13,18 +15,24 @@ def test_run_sandbox(tmp_path: Path):
     assert metrics["network_endpoints"] == ["http://example.com"]
 
 
-def test_collect_permissions():
-    perms = collect_permissions("/tmp/app.apk")
+def test_collect_permissions(tmp_path: Path):
+    apk = tmp_path / "app.apk"
+    apk.write_text("fake")
+    perms = collect_permissions(str(apk))
     assert "android.permission.INTERNET" in perms
 
 
-def test_sniff_network():
-    nets = sniff_network("/tmp/app.apk")
+def test_sniff_network(tmp_path: Path):
+    apk = tmp_path / "app.apk"
+    apk.write_text("fake")
+    nets = sniff_network(str(apk))
     assert nets and nets[0]["destination"] == "example.com"
 
 
 def test_run_analysis(tmp_path: Path):
-    result = run_analysis("/tmp/app.apk", tmp_path)
+    apk = tmp_path / "app.apk"
+    apk.write_text("fake")
+    result = run_analysis(str(apk), tmp_path)
     assert (tmp_path / "permissions.json").exists()
     assert (tmp_path / "network.json").exists()
     assert (tmp_path / "metrics.json").exists()
@@ -37,6 +45,8 @@ def test_run_analysis(tmp_path: Path):
 
 
 def test_run_analysis_disable_hook(tmp_path: Path):
-    result = run_analysis("/tmp/app.apk", tmp_path, disable_hooks=["http_logger"])
+    apk = tmp_path / "app.apk"
+    apk.write_text("fake")
+    result = run_analysis(str(apk), tmp_path, disable_hooks=["http_logger"])
     assert "NETWORK:http://example.com" not in result["messages"]
     assert result["metrics"]["network_endpoints"] == []

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from rotterdam.android.analysis.dynamic.runner import run_sandbox
+
+
+def test_run_sandbox_raises_for_missing_apk(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        run_sandbox(str(tmp_path / "missing.apk"), tmp_path)
+
+
+def test_run_sandbox_collects_metrics(tmp_path: Path) -> None:
+    apk = tmp_path / "dummy.apk"
+    apk.write_text("fake")
+
+    log, metrics, messages = run_sandbox(str(apk), tmp_path, hooks=["crypto_usage", "http_logger"])
+    assert log.exists()
+    # instrumentation should yield at least one event for each category
+    assert metrics["network_endpoint_count"] == 1
+    assert metrics["filesystem_write_count"] == 1
+    assert metrics["unique_permission_count"] == 1
+    assert messages


### PR DESCRIPTION
## Summary
- integrate simple KNN-based classifier trained on baseline metrics
- surface model prediction in pipeline and feed into risk scoring
- run sandboxed analysis inside a temporary isolated workspace
- validate ML inputs and gracefully handle missing baseline data
- wrap ML model import with fallback and require valid APK inputs in sandbox runner

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6025c110c8327b4287c135fd22c74