### PR TITLE
docs: expand setup and architecture guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ On Fedora systems the helper scripts make it easy to set up and launch the CLI:
 ./run.sh --setup          # run setup before launching
 ```
 
+## Setup
+
+The helper script targets Fedora but the same dependencies are available on
+other platforms.
+
+### Fedora
+
+Installed automatically by `setup.sh`:
+
+```
+python3 python3-virtualenv adb aapt2 apktool java-11-openjdk yara
+```
+
+### Debian/Ubuntu
+
+```
+sudo apt-get install python3 python3-venv adb aapt apktool openjdk-11-jdk libyara-dev
+```
+
+### macOS (Homebrew)
+
+```
+brew install python3 adb aapt apktool openjdk@11 yara
+```
+
+Optional tools such as Frida or MySQL can be installed separately if needed.
+
 ## Development
 
 Set up a Python environment and install the project's dependencies.
@@ -61,6 +88,31 @@ python main.py
 
 Analysis results are written to the `output/` directory.
 
+### CLI Examples
+
+#### Static APK analysis
+
+```
+python main.py
+# Analysis → Analyze APK → select /path/to/app.apk
+# Report written to output/<timestamp>/report.json
+```
+
+#### Device scan
+
+```
+python -m cli.actions list-packages <device-serial>
+# Outputs list of installed packages and can export to CSV/JSON
+```
+
+#### Sandbox analysis
+
+```
+python main.py
+# Analysis → Sandbox APK → select /path/to/app.apk
+# See docs/dynamic-analysis.md for hook details
+```
+
 ### Database status
 
 The interactive menu provides a **Database** option that performs a
@@ -82,3 +134,30 @@ This will start a FastAPI application on `localhost:8000` exposing endpoints:
 * `POST /scans` – upload an APK and queue analysis
 * `GET /scans/{id}` – check job status and view the latest risk report
 * `GET /scans/{id}/report?format=json|html` – download the generated report
+
+Example requests:
+
+```
+# submit an APK for analysis
+curl -F "file=@app.apk" http://localhost:8000/scans
+# => {"id":1,"status":"queued"}
+
+# poll job status
+curl http://localhost:8000/scans/1
+# => {"id":1,"status":"complete"}
+
+# download the JSON report
+curl http://localhost:8000/scans/1/report?format=json
+```
+
+Endpoints apply simple request‑ID, authentication, and rate‑limiting middleware.
+
+## Architecture
+
+High-level module interactions are documented in
+[docs/architecture.md](docs/architecture.md).
+
+Additional reference material:
+
+- [Dynamic analysis](docs/dynamic-analysis.md)
+- [Risk scoring](docs/risk-scoring.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,31 @@
+# Rotterdam Architecture
+
+Rotterdam is composed of modular layers that cooperate to analyze Android applications and devices.
+
+## Command Line Interface
+
+The interactive CLI in `cli/` provides menus for interacting with connected devices, running static or dynamic analysis, and starting the API server. Actions under `cli/actions/` wrap the analysis pipelines and persist results in the repository.
+
+## Static Analysis Pipeline
+
+The static pipeline under `platform/android/analysis/static/` decompiles APKs, extracts manifest data, searches for secrets, optionally applies YARA rules, and feeds metrics to the risk‑scoring model. The pipeline's output is a report written to `output/<timestamp>/`.
+
+## Dynamic Sandbox
+
+Dynamic analysis lives in `platform/android/analysis/dynamic/`. The `runner.py` module simulates execution of an APK with Frida instrumentation hooks defined in `frida/`. Observed runtime events are converted into metrics that complement static findings.
+
+## Risk Scoring
+
+The scoring model in `platform/android/analysis/static/scoring/risk_score.py` combines weighted static and dynamic metrics into a normalized 0‑100 score with a human‑readable rationale.
+
+## API Server
+
+A FastAPI application under `server/` exposes REST endpoints for submitting jobs, retrieving reports, querying analytics, and system status. Middleware adds request IDs and basic authentication/rate limiting.
+
+## Data Flow
+
+1. A user launches the CLI and selects an action.
+2. The CLI invokes static or dynamic analysis modules.
+3. Analysis modules generate metrics and artifacts in `output/` and call the risk scorer.
+4. Results are persisted via the `storage` repository and can be served through the API server.
+

--- a/docs/dynamic-analysis.md
+++ b/docs/dynamic-analysis.md
@@ -1,0 +1,33 @@
+# Dynamic Analysis
+
+Rotterdam's dynamic analysis simulates running an APK inside a temporary sandbox and collects runtime behavior.
+
+## Runner
+
+`platform/android/analysis/dynamic/runner.py` orchestrates the sandbox. It executes the target APK, loads Frida hooks, and writes logs and metrics to the specified output directory. The helper returns:
+
+- `sandbox.log` – textual log of the session
+- metrics dictionary summarizing observed behavior
+- raw messages from instrumentation hooks
+
+## Instrumentation Hooks
+
+Hooks are JavaScript snippets located in `platform/android/analysis/dynamic/frida/` and are loaded by `instrumentation.py`. The built-in hooks include:
+
+- `http_logger.js` – records cleartext network endpoints
+- `crypto_usage.js` – notes permission usage and file writes related to cryptography
+
+## Adding Hooks
+
+1. Create a new `.js` file in `platform/android/analysis/dynamic/frida/` emitting messages such as `PERMISSION:`, `NETWORK:` or `FILE_WRITE:`.
+2. Invoke `run_sandbox` with the hook name:
+   ```python
+   from platform.android.analysis.dynamic.runner import run_sandbox
+   run_sandbox("app.apk", outdir, hooks=["http_logger", "my_hook"]) 
+   ```
+3. Metrics from emitted events will appear in `metrics.json` alongside static analysis results.
+
+## UI Exploration
+
+The `ui_driver.py` helper can automate basic interactions with a running app to trigger additional behavior during sandboxing.
+

--- a/docs/risk-scoring.md
+++ b/docs/risk-scoring.md
@@ -1,0 +1,43 @@
+# Risk Scoring Model
+
+The scoring engine in `platform/android/analysis/static/scoring/risk_score.py` combines static and dynamic metrics into a normalized 0–100 risk score.
+
+## Metrics and Weights
+
+Default metric weights are tuned for common risk indicators. Values are normalized internally so weights sum to 1.0.
+
+| Metric | Default Weight |
+| --- | --- |
+| permission_density | 0.23 |
+| component_exposure | 0.15 |
+| permission_invocation_count | 0.18 |
+| cleartext_endpoint_count | 0.12 |
+| file_write_count | 0.08 |
+| malicious_endpoint_count | 0.09 |
+| vulnerable_dependency_count | 0.10 |
+| untrusted_signature | 0.05 |
+| ml_pred_malicious | 0.05 |
+| cleartext_traffic_permitted | 0.04 |
+| missing_certificate_pinning | 0.03 |
+| debug_overrides | 0.01 |
+| expired_certificate | 0.04 |
+| self_signed_certificate | 0.04 |
+
+Count-based metrics are capped before weighting to prevent a single large value from dominating the score. For example, `permission_invocation_count` is capped at 50 calls.
+
+## Customizing Weights
+
+Callers may supply alternative weights or caps:
+
+```python
+from platform.android.analysis.static.scoring.risk_score import calculate_risk_score
+
+static_metrics = {"permission_density": 0.6}
+
+custom_weights = {"permission_density": 0.5, "component_exposure": 0.5}
+result = calculate_risk_score(static_metrics, weights=custom_weights)
+print(result["score"], result["rationale"])
+```
+
+Only the provided keys are overridden; unspecified metrics use defaults. This allows experimentation with different scoring strategies.
+


### PR DESCRIPTION
## Summary
- document cross-platform setup steps
- provide CLI usage examples and API server curl samples
- add architecture, dynamic analysis, and risk scoring docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a62403a710832781a95c58acc875ec