### PR TITLE
Handle unavailable packages during setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,20 @@ fi
 
 if [[ $SKIP_SYSTEM -eq 0 ]]; then
     echo "Installing system dependencies with dnf..."
-    $SUDO dnf install -y python3 python3-virtualenv adb aapt2 apktool java-11-openjdk yara
+    packages=(
+        python3
+        python3-virtualenv
+        adb
+        aapt2
+        apktool
+        java-11-openjdk
+        yara
+    )
+    for pkg in "${packages[@]}"; do
+        if ! $SUDO dnf install -y "$pkg" >/dev/null 2>&1; then
+            echo "Warning: package '$pkg' could not be installed. Please install it manually." >&2
+        fi
+    done
 fi
 
 if [[ $FORCE_VENV -eq 1 && -d .venv ]]; then


### PR DESCRIPTION
## Summary
- Install system packages one by one in setup script
- Warn users about any package that fails to install

## Testing
- `bash -n setup.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6261d351c8327ba4a054482cb6add