### PR TITLE
feat: auto-detect openjdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ other platforms.
 
 ### Fedora
 
-Installed automatically by `setup.sh`:
+Installed automatically by `setup.sh` (defaults to `java-17-openjdk`; override with `JAVA_PACKAGE`):
 
 ```
-python3 python3-virtualenv adb aapt2 apktool java-11-openjdk yara
+python3 python3-virtualenv adb aapt2 apktool java-17-openjdk yara
 ```
+
+By default the script tries to install `java-17-openjdk`. If that package is
+unavailable it falls back to the latest `java-*openjdk` package detected via
+`dnf`. Set the `JAVA_PACKAGE` environment variable to specify a different Java
+package explicitly.
 
 ### Debian/Ubuntu
 


### PR DESCRIPTION
## Summary
- handle OpenJDK selection in setup script, defaulting to java-17-openjdk with fallback to latest available
- document Java package override via JAVA_PACKAGE env var

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6261e59ac8327acf421f7f96e81f1