### PR TITLE
Ensure pyOpenSSL compatibility with cryptography 45

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ httpx==0.28.1
 jmespath==1.0.1
 mysql-connector-python>=9.0.0
 pydantic==2.11.7
+pyopenssl>=25,<26
 pytest==8.4.1
 pytest-cov==6.2.1
 python-multipart==0.0.20


### PR DESCRIPTION
## Summary
- add `pyopenssl` pinned to `25.x` to stay compatible with `cryptography==45.0.6`

## Testing
- `pip install -r requirements.txt`
- `pip check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62887ff848327b876c5072a1dfb41