### PR TITLE
Improve setup handling in run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,18 +13,25 @@ Launch the Rotterdam interactive CLI. Any arguments after `--` are
 passed directly to the Python CLI module.
 
 Options:
-  --setup       Run setup.sh before launching
-  -h, --help    Show this help message
+  --setup        Run setup.sh before launching
+  --setup-only   Run setup.sh and exit
+  -h, --help     Show this help message
 EOF
 }
 
 RUN_SETUP=0
+SETUP_ONLY=0
 CLI_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --setup)
             RUN_SETUP=1
+            shift
+            ;;
+        --setup-only)
+            RUN_SETUP=1
+            SETUP_ONLY=1
             shift
             ;;
         -h|--help)
@@ -45,7 +52,23 @@ done
 
 if [[ $RUN_SETUP -eq 1 || ! -d .venv ]]; then
     echo "Running setup..." >&2
-    ./setup.sh
+    if [[ ! -x ./setup.sh ]]; then
+        echo "setup.sh is missing or not executable. Ensure you're in the project root." >&2
+        exit 1
+    fi
+    ./setup.sh || {
+        status=$?
+        echo "setup.sh failed. You can retry with './setup.sh --skip-system' or manually install the required packages." >&2
+        exit "$status"
+    }
+    if [[ $SETUP_ONLY -eq 1 ]]; then
+        exit 0
+    fi
+fi
+
+if [[ ! -f .venv/bin/activate ]]; then
+    echo "Virtual environment not found. Run './setup.sh' first." >&2
+    exit 1
 fi
 
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- add `--setup-only` flag to run setup without launching the CLI
- verify `setup.sh` existence and virtual env before starting CLI

## Testing
- `pytest`
- `shellcheck run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6288a62208327b9ac99403808044a