### PR TITLE
Allow passing setup options via run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ On Fedora systems the helper scripts make it easy to set up and launch the CLI:
 ./setup.sh --force-venv   # recreate the virtual environment
 ./setup.sh --skip-system  # skip dnf package installation
 ./run.sh --setup          # run setup before launching
+./run.sh --setup --skip-system  # run setup skipping system packages
 ```
 
 ## Setup

--- a/run.sh
+++ b/run.sh
@@ -13,18 +13,32 @@ Launch the Rotterdam interactive CLI. Any arguments after `--` are
 passed directly to the Python CLI module.
 
 Options:
-  --setup       Run setup.sh before launching
-  -h, --help    Show this help message
+  --setup [ARGS]        Run setup.sh before launching; any following arguments
+                        (before `--`) are forwarded to setup.sh
+  --setup-only [ARGS]   Run setup.sh with arguments and exit without launching
+                        the CLI
+  -h, --help            Show this help message
+
+Examples:
+  ./run.sh --setup --skip-system   # run setup skipping system packages
+  ./run.sh --setup-only --skip-system  # run setup and exit
 EOF
 }
 
 RUN_SETUP=0
+RUN_SETUP_ONLY=0
+SETUP_ARGS=()
 CLI_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --setup)
             RUN_SETUP=1
+            shift
+            ;;
+        --setup-only)
+            RUN_SETUP=1
+            RUN_SETUP_ONLY=1
             shift
             ;;
         -h|--help)
@@ -37,7 +51,11 @@ while [[ $# -gt 0 ]]; do
             break
             ;;
         *)
-            CLI_ARGS+=("$1")
+            if [[ $RUN_SETUP -eq 1 ]]; then
+                SETUP_ARGS+=("$1")
+            else
+                CLI_ARGS+=("$1")
+            fi
             shift
             ;;
     esac
@@ -45,7 +63,10 @@ done
 
 if [[ $RUN_SETUP -eq 1 || ! -d .venv ]]; then
     echo "Running setup..." >&2
-    ./setup.sh
+    ./setup.sh "${SETUP_ARGS[@]}"
+    if [[ $RUN_SETUP_ONLY -eq 1 ]]; then
+        exit 0
+    fi
 fi
 
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- forward extra arguments to setup.sh when invoking run.sh with --setup
- add `--setup-only` to run setup without launching the CLI
- document `--setup-only` usage in run.sh help text

## Testing
- `pytest`
- `bash run.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_68a628867dbc8327a21629b84e70cb90