### PR TITLE
feat(cli): enable web app launch from main menu

### DIFF
--- a/cli/menu.py
+++ b/cli/menu.py
@@ -156,7 +156,7 @@ def run_main_menu(*, json_mode: bool = False) -> Optional[Dict[str, Any]]:
                     display.good("Exiting App")
                     return None
         elif num == 5:
-            display.info("Web app launch not implemented yet.")
+            actions.launch_web_app()
         elif num == 6:
             display.info("Application status check not implemented yet.")
         elif num == 7:

--- a/tests/test_cli_menu.py
+++ b/tests/test_cli_menu.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import types
+
+from core import menu as core_menu
+from core import config, display
+
+
+def test_run_main_menu_launches_web_app(monkeypatch):
+    # Prepare stub modules to avoid heavy imports
+    actions_stub = types.ModuleType("cli.actions")
+    launch_called = {"called": False}
+    actions_stub.show_connected_devices = lambda: None
+    actions_stub.show_detailed_devices = lambda: None
+    actions_stub.scan_for_devices = lambda: None
+    actions_stub.launch_web_app = lambda *a, **k: launch_called.__setitem__("called", True)
+    sys.modules["cli.actions"] = actions_stub
+
+    selection_stub = types.ModuleType("devices.selection")
+    selection_stub.list_and_select_device = lambda: None
+    sys.modules["devices.selection"] = selection_stub
+
+    choices = [5, 0]
+    monkeypatch.setattr(core_menu, "show_menu", lambda *a, **k: choices.pop(0))
+    monkeypatch.setattr(config, "ensure_dirs", lambda: None)
+    monkeypatch.setattr(display, "print_app_banner", lambda *a, **k: None)
+
+    cli_menu = importlib.import_module("cli.menu")
+    cli_menu.run_main_menu()
+
+    assert launch_called["called"]


### PR DESCRIPTION
## Summary
- allow main menu option 5 to start the web interface
- add regression test ensuring menu triggers launch

## Testing
- `python -m pytest tests/test_cli_menu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6390f77c08327bf8217fe6f756bcf