### PR TITLE
Add run_as_root helper for privileged setup steps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,17 @@ FORCE_VENV=0
 SKIP_SYSTEM=0
 FAILED_PACKAGES=()
 
+run_as_root() {
+    if command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    elif [[ ${EUID:-0} -eq 0 ]]; then
+        "$@"
+    else
+        echo "Root privileges are required: $*" >&2
+        return 1
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --force-venv) FORCE_VENV=1; shift ;;
@@ -42,21 +53,10 @@ else
     exit 1
 fi
 
-if [[ ${EUID:-0} -ne 0 ]]; then
-    if command -v sudo >/dev/null 2>&1; then
-        SUDO="sudo"
-    else
-        echo "Root privileges are required to install system dependencies." >&2
-        exit 1
-    fi
-else
-    SUDO=""
-fi
-
 if [[ $PKG_MANAGER == "dnf" ]]; then
-    PKG_INSTALL_CMD="$SUDO dnf install -y"
+    PKG_INSTALL_CMD=(dnf install -y)
 else
-    PKG_INSTALL_CMD="$SUDO apt-get install -y"
+    PKG_INSTALL_CMD=(apt-get install -y)
 fi
 
 if [[ $SKIP_SYSTEM -eq 0 ]]; then
@@ -110,7 +110,7 @@ if [[ $SKIP_SYSTEM -eq 0 ]]; then
             "$JAVA_PKG"
         )
         echo "Updating package list..."
-        if ! $SUDO apt-get update 2>&1 | tee -a system_install.log; then
+        if ! run_as_root apt-get update 2>&1 | tee -a system_install.log; then
             echo "Failed to update package list" | tee -a system_install.log >&2
             exit 1
         fi
@@ -118,7 +118,7 @@ if [[ $SKIP_SYSTEM -eq 0 ]]; then
 
     for pkg in "${packages[@]}"; do
         echo "Installing $pkg..."
-        if ! $PKG_INSTALL_CMD "$pkg" 2>&1 | tee -a system_install.log; then
+        if ! run_as_root "${PKG_INSTALL_CMD[@]}" "$pkg" 2>&1 | tee -a system_install.log; then
             echo "Failed to install $pkg" | tee -a system_install.log >&2
             FAILED_PACKAGES+=("$pkg")
         fi
@@ -177,6 +177,16 @@ if [[ ${#FAILED_PACKAGES[@]} -gt 0 ]]; then
     echo "The following packages failed to install: ${FAILED_PACKAGES[*]}" >&2
     echo "You may need to install them manually. See system_install.log for details." >&2
     exit 1
+fi
+
+# Create a convenient symlink to the CLI if absent
+if [[ -n "${SUDO_USER:-}" && ! -e /usr/local/bin/rotterdam ]]; then
+    run_as_root ln -sf "$ROOT_DIR/run.sh" /usr/local/bin/rotterdam
+fi
+
+# Ensure the output directory is owned by the invoking user
+if [[ -n "${SUDO_USER:-}" && -d "$ROOT_DIR/output" ]]; then
+    run_as_root chown -R "$SUDO_USER":"$SUDO_USER" "$ROOT_DIR/output"
 fi
 
 echo "Setup complete. Run ./run.sh to start the application."


### PR DESCRIPTION
## Summary
- add `run_as_root` shell helper to use sudo when available or run directly as root
- use helper for package installation and `apt-get` updates
- invoke helper for CLI symlink creation and output directory ownership normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a63b889c288327811b846adfe33bc7