### PR TITLE
Serve web UI index and static assets at root

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from .middleware import AuthRateLimitMiddleware, RequestIDMiddleware
 from .routers import (
@@ -21,3 +23,11 @@ app.include_router(jobs_router)
 app.include_router(reports_router)
 app.include_router(analytics_router)
 app.include_router(system_router)
+
+app.mount("/ui", StaticFiles(directory="ui"), name="ui")
+
+
+@app.get("/", include_in_schema=False)
+async def index() -> FileResponse:  # pragma: no cover - trivial redirect
+    """Serve the web UI's index page."""
+    return FileResponse("ui/pages/index.html")

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -11,6 +11,14 @@ client = TestClient(app)
 HEADERS = {"X-API-Key": "secret"}
 
 
+def test_ui_index_served():
+    resp = client.get("/", headers=HEADERS)
+    assert resp.status_code == 200
+    assert "Rotterdam Dashboard" in resp.text
+
+    resp = client.get("/ui/js/helpers.js", headers=HEADERS)
+    assert resp.status_code == 200
+
 def test_job_lifecycle():
     # Devices endpoint should always return a list
     resp = client.get("/devices", headers=HEADERS)


### PR DESCRIPTION
## Summary
- mount UI directory for static file hosting and serve web UI index at `/`
- cover root and static paths with a new FastAPI server test

## Testing
- `pytest tests/test_server_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63ebeb40c8327b3609de6f9539054