### PR TITLE
Serve web UI via static files

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 
 from .middleware import AuthRateLimitMiddleware, RequestIDMiddleware
 from .routers import (
@@ -21,3 +24,21 @@ app.include_router(jobs_router)
 app.include_router(reports_router)
 app.include_router(analytics_router)
 app.include_router(system_router)
+
+# Serve static files for the web UI
+app.mount("/static", StaticFiles(directory="ui"), name="static")
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> FileResponse:
+    """Return the main dashboard page."""
+    return FileResponse(Path("ui/pages/index.html"))
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon() -> FileResponse:
+    """Serve the favicon if present."""
+    path = Path("ui/favicon.ico")
+    if path.exists():
+        return FileResponse(path)
+    raise HTTPException(status_code=404)

--- a/tests/test_server_static.py
+++ b/tests/test_server_static.py
@@ -1,0 +1,20 @@
+"""Tests for serving the web UI and static assets."""
+
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+client = TestClient(app)
+HEADERS = {"X-API-Key": "secret"}
+
+
+def test_root_serves_index_page():
+    resp = client.get("/", headers=HEADERS)
+    assert resp.status_code == 200
+    assert "Rotterdam Dashboard" in resp.text
+
+
+def test_static_files_served():
+    resp = client.get("/static/js/helpers.js", headers=HEADERS)
+    assert resp.status_code == 200
+    assert "window.api" in resp.text


### PR DESCRIPTION
## Summary
- Serve the `ui` directory as static files and expose a root route for the dashboard
- Add tests verifying the web UI and static assets are delivered

## Testing
- `pytest tests/test_server_api.py tests/test_server_static.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63f7a16008327b5c793916d038919