### PR TITLE
chore(server): remove redundant health endpoint

### DIFF
--- a/server/routers/system.py
+++ b/server/routers/system.py
@@ -11,13 +11,6 @@ router = APIRouter()
 
 _start_time = time.time()
 
-
-@router.get("/_healthz", include_in_schema=False)
-async def health() -> dict[str, str]:
-    """Simple health check endpoint."""
-    return {"status": "ok"}
-
-
 @router.get("/_stats", include_in_schema=False)
 async def stats() -> dict[str, float | int]:
     """Internal statistics about the server."""


### PR DESCRIPTION
## Summary
- remove duplicate `/_healthz` endpoint from diagnostics router
- rely on central `/_healthz` implementation in `server/main.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64b17346c8327b5d56b36bcb56b57