### PR TITLE
Implement periodic request log cleanup

### DIFF
--- a/tests/test_rate_limit_cleanup.py
+++ b/tests/test_rate_limit_cleanup.py
@@ -1,0 +1,19 @@
+from collections import deque
+
+from server import middleware
+
+
+def setup_function():
+    middleware._request_log.clear()
+    middleware._last_cleanup = 0
+
+
+def test_cleanup_removes_empty_and_stale_entries():
+    middleware._request_log["empty"] = deque()
+    middleware._request_log["stale"] = deque([0])
+    now = middleware.RATE_WINDOW_SECS + 1
+    middleware._cleanup_request_log(now)
+    assert "empty" not in middleware._request_log
+    assert "stale" not in middleware._request_log
+
+


### PR DESCRIPTION
## Summary
- add periodic cleanup for stale request log entries in middleware
- test request log cleanup behavior

## Testing
- `pytest tests/test_rate_limit_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a64b1a1484832783d414fb6d0f8ca4