### PR TITLE
Warn on default API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,17 @@ development.
 ## API Server
 
 A lightweight REST API can be launched to submit APKs for analysis and
-retrieve risk reports.  Start the server via the CLI:
+retrieve risk reports. Set a custom API key via `ROTTERDAM_API_KEY` and start
+the server via the CLI:
 
 ```bash
+export ROTTERDAM_API_KEY="my-strong-key"  # default "secret" will trigger a warning
 python -m cli.actions serve
 ```
 
-This will start a FastAPI application on `localhost:8000` exposing endpoints:
+Using the default key is only suitable for local testing and will log a
+critical warning on startup. This will start a FastAPI application on
+`localhost:8000` exposing endpoints:
 
 * `POST /scans` – upload an APK and queue analysis
 * `GET /scans/{id}` – check job status and view the latest risk report

--- a/server/main.py
+++ b/server/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse, PlainTextResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from .middleware import AuthRateLimitMiddleware, RequestIDMiddleware
+from .middleware import AuthRateLimitMiddleware, RequestIDMiddleware, DEFAULT_API_KEY
 from .routers import (
     analytics_router,
     devices_router,
@@ -73,6 +73,11 @@ async def _startup_checks() -> None:
         log.warning("UI directory missing — static mounts will 404: %s", UI_DIR)
     if not INDEX_HTML.exists():
         log.warning("Index file missing — GET / will 500: %s", INDEX_HTML)
+    api_key = os.getenv("ROTTERDAM_API_KEY", DEFAULT_API_KEY)
+    if api_key == DEFAULT_API_KEY:
+        log.critical(
+            "ROTTERDAM_API_KEY is using the default value; set a custom key for production"
+        )
 
 # ---------- Health / diagnostics ----------
 @app.get("/_healthz", include_in_schema=False)

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -19,8 +19,9 @@ from starlette.middleware.base import BaseHTTPMiddleware
 # Config
 # -----------------------------------------------------------------------------
 
-# Comma-separated list of valid API keys. Default "secret".
-_API_KEYS_ENV = os.getenv("ROTTERDAM_API_KEY", "secret")
+# Comma-separated list of valid API keys. Default "secret" (development only).
+DEFAULT_API_KEY = "secret"
+_API_KEYS_ENV = os.getenv("ROTTERDAM_API_KEY", DEFAULT_API_KEY)
 API_KEYS: set[str] = {k.strip() for k in _API_KEYS_ENV.split(",") if k.strip()}
 
 # Allow up to N requests per minute per client (IP or token).


### PR DESCRIPTION
## Summary
- log critical warning if ROTTERDAM_API_KEY uses the development default
- document requirement for setting ROTTERDAM_API_KEY to a custom value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a64b1a9d0883278f01eb9aa7c9a7bc