### PR TITLE
Allow unauthenticated access to UI and static mounts

### DIFF
--- a/server/middleware.py
+++ b/server/middleware.py
@@ -32,8 +32,17 @@ DISABLE_AUTH = os.getenv("DISABLE_AUTH", "").lower() in {"1", "true", "yes", "on
 TRUST_LOCALHOST = os.getenv("TRUST_LOCALHOST", "").lower() in {"1", "true", "yes", "on"}
 TRUST_PROXY = os.getenv("TRUST_PROXY", "").lower() in {"1", "true", "yes", "on"}
 
-# Public routes (no auth). Prefixes cover static mounts.
-PUBLIC_PATHS: set[str] = {"/", "/favicon.ico", "/_healthz", "/_ready", "/_diag"}
+# Public routes (no auth). Prefixes cover static mounts and we
+# explicitly include the mount roots themselves.
+PUBLIC_PATHS: set[str] = {
+    "/",
+    "/favicon.ico",
+    "/_healthz",
+    "/_ready",
+    "/_diag",
+    "/ui",
+    "/static",
+}
 PUBLIC_PREFIXES: tuple[str, ...] = ("/ui/", "/static/")
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- treat `/ui` and `/static` mount roots as public paths so static files and the dashboard can load without an API key

## Testing
- `pytest tests/test_server_static.py tests/test_server_api.py::test_ui_index_served -q`

------
https://chatgpt.com/codex/tasks/task_e_68a64b19da348327a8ba6a4677ff73e3