### PR TITLE
Secure diagnostic endpoint and mask paths

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -25,6 +25,14 @@ UI_DIR = (REPO_ROOT / "ui").resolve()
 INDEX_HTML = UI_DIR / "pages" / "index.html"
 FAVICON_ICO = UI_DIR / "favicon.ico"
 
+
+def _mask_path(p: Path) -> str:
+    """Return repo-relative path to avoid leaking full filesystem layout."""
+    try:
+        return str(p.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return f".../{p.name}"
+
 # Optional base path if served behind a proxy (e.g., /rotterdam)
 ROOT_PATH = os.getenv("ROOT_PATH", "")
 
@@ -89,9 +97,9 @@ async def diag() -> JSONResponse:
     return JSONResponse(
         {
             "root_path": ROOT_PATH,
-            "ui_dir": str(UI_DIR),
-            "index_html": {"path": str(INDEX_HTML), "exists": INDEX_HTML.exists()},
-            "favicon_ico": {"path": str(FAVICON_ICO), "exists": FAVICON_ICO.exists()},
+            "ui_dir": _mask_path(UI_DIR),
+            "index_html": {"path": _mask_path(INDEX_HTML), "exists": INDEX_HTML.exists()},
+            "favicon_ico": {"path": _mask_path(FAVICON_ICO), "exists": FAVICON_ICO.exists()},
         }
     )
 

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -33,7 +33,8 @@ TRUST_LOCALHOST = os.getenv("TRUST_LOCALHOST", "").lower() in {"1", "true", "yes
 TRUST_PROXY = os.getenv("TRUST_PROXY", "").lower() in {"1", "true", "yes", "on"}
 
 # Public routes (no auth). Prefixes cover static mounts.
-PUBLIC_PATHS: set[str] = {"/", "/favicon.ico", "/_healthz", "/_ready", "/_diag"}
+# /_diag is intentionally excluded to require authentication or a dev flag.
+PUBLIC_PATHS: set[str] = {"/", "/favicon.ico", "/_healthz", "/_ready"}
 PUBLIC_PREFIXES: tuple[str, ...] = ("/ui/", "/static/")
 
 # -----------------------------------------------------------------------------

--- a/tests/test_server_diag.py
+++ b/tests/test_server_diag.py
@@ -1,0 +1,23 @@
+"""Tests for the /_diag endpoint security and output."""
+
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+client = TestClient(app)
+HEADERS = {"X-API-Key": "secret"}
+
+
+def test_diag_requires_auth_and_masks_paths() -> None:
+    """Unauthenticated requests should be rejected and paths masked in responses."""
+    resp = client.get("/_diag")
+    assert resp.status_code == 401
+
+    resp = client.get("/_diag", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert not data["ui_dir"].startswith("/")
+    assert not data["index_html"]["path"].startswith("/")
+    assert not data["favicon_ico"]["path"].startswith("/")


### PR DESCRIPTION
## Summary
- Require authentication for `/_diag` by removing it from public routes
- Mask filesystem paths in diagnostic output to avoid leaking directory structure
- Test coverage for `/_diag` ensuring auth requirement and path masking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64b188e6c8327bedd4cc6d04dcb20