### PR TITLE
Align run script and docs with server default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ retrieve risk reports.  Start the server via the CLI:
 python -m cli.actions serve
 ```
 
-This will start a FastAPI application on `localhost:8000` exposing endpoints:
+This will start a FastAPI application on `localhost:8765` exposing endpoints:
 
 * `POST /scans` – upload an APK and queue analysis
 * `GET /scans/{id}` – check job status and view the latest risk report
@@ -144,15 +144,15 @@ Example requests:
 
 ```
 # submit an APK for analysis
-curl -F "file=@app.apk" http://localhost:8000/scans
+curl -F "file=@app.apk" http://localhost:8765/scans
 # => {"id":1,"status":"queued"}
 
 # poll job status
-curl http://localhost:8000/scans/1
+curl http://localhost:8765/scans/1
 # => {"id":1,"status":"complete"}
 
 # download the JSON report
-curl http://localhost:8000/scans/1/report?format=json
+curl http://localhost:8765/scans/1/report?format=json
 ```
 
 Endpoints apply simple request‑ID, authentication, and rate‑limiting middleware.

--- a/cli/actions/__main__.py
+++ b/cli/actions/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from server.serv_config import DEFAULT_HOST, DEFAULT_PORT
 from . import list_installed_packages, run_server
 
 
@@ -13,8 +14,8 @@ def main(argv: list[str] | None = None) -> None:
     sub = parser.add_subparsers(dest="cmd")
 
     p_serve = sub.add_parser("serve", help="start API server")
-    p_serve.add_argument("--host", default="127.0.0.1")
-    p_serve.add_argument("--port", type=int, default=8000)
+    p_serve.add_argument("--host", default=DEFAULT_HOST)
+    p_serve.add_argument("--port", type=int, default=DEFAULT_PORT)
 
     p_list = sub.add_parser("list-packages", help="list installed packages")
     p_list.add_argument("serial", help="device serial")

--- a/cli/actions/server.py
+++ b/cli/actions/server.py
@@ -15,6 +15,7 @@ from storage.repository import (
     ping_db,
 )
 
+from server.serv_config import DEFAULT_HOST, DEFAULT_PORT
 from .utils import action_context as _action_context, logger
 
 
@@ -72,7 +73,7 @@ def show_database_status() -> None:
         print("No analysis records found.")
 
 
-def launch_web_app(host: str = "127.0.0.1", port: int = 8000) -> None:
+def launch_web_app(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:
     """Launch the web interface, starting the server if needed."""
     import uvicorn
 
@@ -99,7 +100,7 @@ def launch_web_app(host: str = "127.0.0.1", port: int = 8000) -> None:
     webbrowser.open(f"http://{host}:{port}")
 
 
-def run_server(host: str = "127.0.0.1", port: int = 8000) -> None:
+def run_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:
     """Start the API server using uvicorn."""
     import uvicorn
 

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@
 # Why this script:
 # - Always run from repo root (no CWD surprises)
 # - Auto-run setup.sh if .venv is missing (or use --setup / --setup-only)
-# - Hard-code default WEB PORT (8000) once, and pass it to the app via env
+# - Source default WEB HOST/PORT from server/serv_config.py for consistency
 # - Add diagnostics (--check) to catch common issues early
 # - Keep behavior simple: this script launches the CLI menu (python main.py)
 #
@@ -43,10 +43,18 @@ SCRIPT_PATH="$(resolve_path "$0")"
 ROOT_DIR="$(dirname "$SCRIPT_PATH")"
 cd "$ROOT_DIR"
 
-# ------------------------------ Hard-coded defaults -------------------------
-# Single source of truth for local web bind settings (used by CLI-launched server).
-APP_HOST_DEFAULT="127.0.0.1"
-APP_PORT_DEFAULT=8000     # <— hard-coded default port per project convention
+# ------------------------------ Default settings ---------------------------
+# Source defaults from server/serv_config.py to avoid divergence.
+APP_HOST_DEFAULT="$(python - <<'PY'
+from server.serv_config import DEFAULT_HOST
+print(DEFAULT_HOST)
+PY
+)"
+APP_PORT_DEFAULT="$(python - <<'PY'
+from server.serv_config import DEFAULT_PORT
+print(DEFAULT_PORT)
+PY
+)"
 
 # ------------------------------- CLI options --------------------------------
 RUN_SETUP=0


### PR DESCRIPTION
## Summary
- Delegate `run.sh` defaults to `server/serv_config` so host/port stay in sync
- Use shared DEFAULT_HOST/PORT in CLI modules
- Update README examples to reflect new default port 8765

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a64b1706388327b730b058399d350b