### PR TITLE
Add server security and rate limit tests

### DIFF
--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -94,14 +94,10 @@ def test_job_lifecycle():
 
 
 def test_hidden_endpoints_and_headers():
-    resp = client.get("/_healthz", headers=HEADERS)
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "ok"
-    assert "X-Request-ID" in resp.headers
-
     resp = client.get("/_stats", headers=HEADERS)
     assert resp.status_code == 200
     assert "jobs" in resp.json()
+    assert "X-Request-ID" in resp.headers
 
     resp = client.get("/devices", headers=HEADERS)
     assert "X-RateLimit-Remaining" in resp.headers

--- a/tests/test_server_security.py
+++ b/tests/test_server_security.py
@@ -1,0 +1,43 @@
+"""Additional server security and rate limit tests."""
+
+from fastapi.testclient import TestClient
+
+from server.main import app
+from server import middleware
+
+client = TestClient(app)
+HEADERS = {"X-API-Key": "secret"}
+
+
+def test_root_includes_request_id():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "X-Request-ID" in resp.headers
+
+
+def test_css_served_without_auth():
+    resp = client.get("/ui/css/styles.css")
+    assert resp.status_code == 200
+    assert resp.text  # ensure content returned
+
+
+def test_secure_endpoint_requires_api_key():
+    resp = client.get("/devices")
+    assert resp.status_code == 401
+
+    resp = client.get("/devices", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_rate_limit_enforced(monkeypatch):
+    monkeypatch.setattr(middleware, "RATE_LIMIT", 2)
+    middleware._request_log.clear()
+
+    for _ in range(2):
+        r = client.get("/devices", headers=HEADERS)
+        assert r.status_code == 200
+    r = client.get("/devices", headers=HEADERS)
+    assert r.status_code == 429
+    assert r.headers.get("X-RateLimit-Limit") == "2"
+    assert r.headers.get("X-RateLimit-Remaining") == "0"
+    assert "X-RateLimit-Reset" in r.headers


### PR DESCRIPTION
## Summary
- add tests for request ID header, static assets, API key enforcement, and rate limiting
- clean up diagnostics test to use _stats endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a655988fac83278774cd444a8d12d8