### PR TITLE
Simplify UI asset paths and middleware

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -48,12 +48,6 @@ app.add_middleware(AuthRateLimitMiddleware)
 _STATIC_PREFIXES = (
     "/ui/",
     "/static/",
-    "/css/",
-    "/js/",
-    "/images/",
-    "/img/",
-    "/fonts/",
-    "/partials/",   # added to cover HTML fragments
 )
 
 @app.middleware("http")
@@ -80,19 +74,6 @@ app.include_router(system_router)  # owns /_healthz (and /_ready if present)
 # Use check_dir=False so startup won't crash if UI_DIR is missing (we log warnings).
 app.mount("/ui", StaticFiles(directory=str(UI_DIR), check_dir=False), name="ui")
 app.mount("/static", StaticFiles(directory=str(UI_DIR), check_dir=False), name="static")
-
-# Conditionally mount common asset roots if those folders exist (prevents startup errors)
-for mount, subdir in (
-    ("/css", "css"),
-    ("/js", "js"),
-    ("/images", "images"),
-    ("/img", "img"),
-    ("/fonts", "fonts"),
-    ("/partials", "partials"),  # NEW: HTML fragments like header/footer/sidebar
-):
-    d = UI_DIR / subdir
-    if d.exists():
-        app.mount(mount, StaticFiles(directory=str(d)), name=subdir)
 
 # ---------- Startup diagnostics ----------
 @app.on_event("startup")

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -57,20 +57,10 @@ PUBLIC_PATHS: set[str] = {
     "/_ready",
     "/ui",
     "/static",
-    "/css",
-    "/js",
-    "/images",
-    "/img",
-    "/fonts",
 }
 PUBLIC_PREFIXES: tuple[str, ...] = (
     "/ui/",
     "/static/",
-    "/css/",
-    "/js/",
-    "/images/",
-    "/img/",
-    "/fonts/",
 )
 
 # -----------------------------------------------------------------------------

--- a/server/routers/system.py
+++ b/server/routers/system.py
@@ -11,6 +11,11 @@ router = APIRouter()
 
 _start_time = time.time()
 
+@router.get("/_healthz", include_in_schema=False)
+async def health() -> dict[str, str]:
+    """Liveness probe."""
+    return {"status": "ok"}
+
 @router.get("/_stats", include_in_schema=False)
 async def stats() -> dict[str, float | int]:
     """Internal statistics about the server."""

--- a/ui/js/helpers.js
+++ b/ui/js/helpers.js
@@ -1,4 +1,4 @@
-const BASE_PATH = window.location.pathname.includes('/pages/') ? '..' : '.';
+const BASE_PATH = '/ui';
 
 $(function () {
   $('#header').load(`${BASE_PATH}/partials/header.html`);

--- a/ui/pages/analytics.html
+++ b/ui/pages/analytics.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Analytics - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'analytics';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/analyze.html
+++ b/ui/pages/analyze.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Analyze - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'analyze';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/current-device.html
+++ b/ui/pages/current-device.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Current Device - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'current-device';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/device-stats.html
+++ b/ui/pages/device-stats.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Device Stats - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'device-stats';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/devices.html
+++ b/ui/pages/devices.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Devices - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'devices';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/index.html
+++ b/ui/pages/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Rotterdam Dashboard</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'dashboard';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/jobs.html
+++ b/ui/pages/jobs.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Jobs - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'jobs';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/report-detail.html
+++ b/ui/pages/report-detail.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Report Detail - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'report-detail';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>

--- a/ui/pages/reports.html
+++ b/ui/pages/reports.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>Reports - Rotterdam</title>
-    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="../js/helpers.js"></script>
+    <script src="/ui/js/helpers.js"></script>
     <script>
       window.INITIAL_PAGE = 'reports';
     </script>
-    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="/ui/js/main.js"></script>
   </head>
   <body>
     <div id="header"></div>


### PR DESCRIPTION
## Summary
- reference UI assets with `/ui/...` URLs
- trim redundant static mounts and public paths
- add missing health check endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6559bd7208327b1032496fb62bc1e