### PR TITLE
chore: configure black and isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.isort]
+profile = "black"
+known_first_party = ["server", "cli"]


### PR DESCRIPTION
## Summary
- configure Black with Python 3.12 target and 100 character line length
- align isort with Black and mark server and cli as first-party imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6574b8e788327a8c167c15be11b6f