### PR TITLE
Add git attributes for binaries and generated assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.ico binary
+*.apk binary
+
+ui/dist/* linguist-generated merge=ours
+
+# Lock files - use ours merge driver to avoid conflicts
+package-lock.json merge=ours
+yarn.lock merge=ours
+pnpm-lock.yaml merge=ours
+Pipfile.lock merge=ours
+poetry.lock merge=ours


### PR DESCRIPTION
## Summary
- Normalize line endings and mark binary assets in `.gitattributes`
- Treat `ui/dist` output as generated and avoid merging common lock files

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a6574816488327aa780adc3562f80d