### PR TITLE
Allow unauthenticated access to UI partials

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -53,7 +53,6 @@ _STATIC_PREFIXES = (
     "/images/",
     "/img/",
     "/fonts/",
-    "/partials/",   # added to cover HTML fragments
 )
 
 @app.middleware("http")
@@ -88,7 +87,6 @@ for mount, subdir in (
     ("/images", "images"),
     ("/img", "img"),
     ("/fonts", "fonts"),
-    ("/partials", "partials"),  # NEW: HTML fragments like header/footer/sidebar
 ):
     d = UI_DIR / subdir
     if d.exists():

--- a/server/routers/system.py
+++ b/server/routers/system.py
@@ -11,6 +11,11 @@ router = APIRouter()
 
 _start_time = time.time()
 
+@router.get("/_healthz", include_in_schema=False)
+async def healthz() -> dict[str, str]:
+    """Liveness probe for uptime checks."""
+    return {"status": "ok"}
+
 @router.get("/_stats", include_in_schema=False)
 async def stats() -> dict[str, float | int]:
     """Internal statistics about the server."""

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -106,3 +106,13 @@ def test_hidden_endpoints_and_headers():
     resp = client.get("/devices", headers=HEADERS)
     assert "X-RateLimit-Remaining" in resp.headers
 
+
+def test_partials_public_and_healthz_no_auth():
+    resp = client.get("/ui/partials/header.html")
+    assert resp.status_code == 200
+    assert "Rotterdam" in resp.text
+
+    resp = client.get("/_healthz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+

--- a/ui/js/helpers.js
+++ b/ui/js/helpers.js
@@ -1,9 +1,9 @@
 const BASE_PATH = window.location.pathname.includes('/pages/') ? '..' : '.';
 
 $(function () {
-  $('#header').load(`${BASE_PATH}/partials/header.html`);
-  $('#footer').load(`${BASE_PATH}/partials/footer.html`);
-  $('#sidebar').load(`${BASE_PATH}/partials/sidebar.html`, function () {
+  $('#header').load(`${BASE_PATH}/ui/partials/header.html`);
+  $('#footer').load(`${BASE_PATH}/ui/partials/footer.html`);
+  $('#sidebar').load(`${BASE_PATH}/ui/partials/sidebar.html`, function () {
     const page = window.location.pathname.split('/').pop();
     $(`#sidebar a[href='${page}']`).addClass('active');
   });


### PR DESCRIPTION
## Summary
- Serve HTML partials solely under `/ui` and drop dedicated `/partials` path
- Allow unauthenticated access to partial templates via existing `/ui` prefix
- Expose a simple `/_healthz` liveness endpoint
- Add tests confirming partial templates and health check are publicly accessible

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6559c4cb48327a4b2f9e53bbb455b