### PR TITLE
Add pre-commit configuration and installer script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ['--profile=black']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\\.md$'
+      - id: end-of-file-fixer
+        exclude: '\\.md$'

--- a/scripts/install-precommit.sh
+++ b/scripts/install-precommit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pre-commit install


### PR DESCRIPTION
## Summary
- configure pre-commit with black, isort, trailing whitespace and EOF hooks
- exclude Markdown files and add install-precommit helper script

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/install-precommit.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6574b314c8327ad8b0e0ce6b45118