### PR TITLE
Add central server constants

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -7,9 +7,10 @@ from fastapi import FastAPI
 from orchestrator.worker import start_worker
 
 from .routes import router
+from .constants import APP_NAME, APP_VERSION
 
 # FastAPI application
-app = FastAPI(title="Rotterdam Scanner API")
+app = FastAPI(title=APP_NAME, version=APP_VERSION)
 app.include_router(router)
 
 # Background worker to process scheduled jobs

--- a/server/constants.py
+++ b/server/constants.py
@@ -1,0 +1,14 @@
+"""Application-wide constants for the Rotterdam server."""
+
+from __future__ import annotations
+
+
+# Name of the FastAPI application
+APP_NAME: str = "Rotterdam API"
+
+# Semantic version of the application
+APP_VERSION: str = "0.1.0"
+
+
+__all__ = ["APP_NAME", "APP_VERSION"]
+

--- a/server/main.py
+++ b/server/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse, PlainTextResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from .constants import APP_NAME, APP_VERSION
 from .middleware import AuthRateLimitMiddleware, RequestIDMiddleware, DEFAULT_API_KEY
 from .routers import (
     analytics_router,
@@ -35,7 +36,7 @@ def _mask_path(p: Path) -> str:
 # Optional base path if served behind a proxy (e.g., /rotterdam)
 ROOT_PATH = os.getenv("ROOT_PATH", "")
 
-app = FastAPI(title="Rotterdam API", root_path=ROOT_PATH)
+app = FastAPI(title=APP_NAME, version=APP_VERSION, root_path=ROOT_PATH)
 
 # ---------- Logging ----------
 log = logging.getLogger("uvicorn.error")


### PR DESCRIPTION
## Summary
- add `server/constants.py` with `APP_NAME` and `APP_VERSION`
- use shared constants when creating FastAPI apps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a65752e46c832797dea40d00e1f7e1