### PR TITLE
Document static file placement for web UI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ The scoring model in `platform/android/analysis/static/scoring/risk_score.py` co
 
 ## API Server
 
-A FastAPI application under `server/` exposes REST endpoints for submitting jobs, retrieving reports, querying analytics, and system status. Middleware adds request IDs and basic authentication/rate limiting.
+A FastAPI application under `server/` exposes REST endpoints for submitting jobs, retrieving reports, querying analytics, and system status. Middleware adds request IDs and basic authentication/rate limiting. Static files for the web UI must reside under the repository's `ui/` directory so they can be mounted at `/ui` and `/static`.
 
 ## Data Flow
 

--- a/server/main.py
+++ b/server/main.py
@@ -21,6 +21,8 @@ from .routers import (
 # ---------- Paths (robust to CWD) ----------
 THIS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = THIS_DIR.parent
+# NOTE: All static files must live under ``/ui/...`` relative to the repository
+# root so that the mounts below can serve them correctly.
 UI_DIR = (REPO_ROOT / "ui").resolve()
 INDEX_HTML = UI_DIR / "pages" / "index.html"
 FAVICON_ICO = UI_DIR / "favicon.ico"

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -63,6 +63,9 @@ PUBLIC_PATHS: set[str] = {
     "/img",
     "/fonts",
 }
+# Static asset paths are rooted under ``/ui/...``; these prefixes mirror
+# subdirectories within that directory so the middleware can quickly identify
+# requests for static files.
 PUBLIC_PREFIXES: tuple[str, ...] = (
     "/ui/",
     "/static/",

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,5 +1,8 @@
 """API routes for submitting APK scans and retrieving results."""
 
+# NOTE: Static files must reside under ``/ui/...`` so the server can mount them
+# consistently. See ``server/main.py`` for the associated mount points.
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- Document that static assets must live under `/ui/...` in server routes and configuration
- Clarify static asset location in architecture docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a65752afe883278162db9c774b5b03