### PR TITLE
Add editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- enforce LF line endings, trailing newline, trim whitespace across repo
- configure Python and shell scripts to use 4-space indentation
- preserve trailing whitespace in Markdown files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6574821008327915f00c462e8900b