### PR TITLE
Add basic test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load(name: str, relative: str):
+    path = ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
+# Provide a minimal ``rotterdam`` namespace for modules expecting it.
+if "rotterdam" not in sys.modules:
+    rotterdam = types.ModuleType("rotterdam")
+    rotterdam.__path__ = [str(ROOT)]
+    sys.modules["rotterdam"] = rotterdam
+
+    android_pkg = types.ModuleType("rotterdam.android")
+    android_pkg.__path__ = [str(ROOT / "platform" / "android")]
+    sys.modules["rotterdam.android"] = android_pkg
+
+    devices_pkg = types.ModuleType("rotterdam.android.devices")
+    devices_pkg.__path__ = [str(ROOT / "platform" / "android" / "devices")]
+    sys.modules["rotterdam.android.devices"] = devices_pkg
+    _load("rotterdam.android.devices.discovery", "platform/android/devices/discovery.py")
+    _load("rotterdam.android.devices.props", "platform/android/devices/props.py")
+    _load("rotterdam.android.devices.adb", "platform/android/devices/adb.py")
+
+    analysis_pkg = types.ModuleType("rotterdam.android.analysis")
+    analysis_pkg.__path__ = [str(ROOT / "platform" / "android" / "analysis")]
+    sys.modules["rotterdam.android.analysis"] = analysis_pkg
+
+    static_pkg = types.ModuleType("rotterdam.android.analysis.static")
+    static_pkg.__path__ = [str(ROOT / "platform" / "android" / "analysis" / "static")]
+    sys.modules["rotterdam.android.analysis.static"] = static_pkg
+
+    extractors_pkg = types.ModuleType("rotterdam.android.analysis.static.extractors")
+    extractors_pkg.__path__ = [
+        str(ROOT / "platform" / "android" / "analysis" / "static" / "extractors")
+    ]
+    sys.modules["rotterdam.android.analysis.static.extractors"] = extractors_pkg
+    _load(
+        "rotterdam.android.analysis.static.extractors.manifest",
+        "platform/android/analysis/static/extractors/manifest.py",
+    )
+
+# Stub out optional dependency used by job_service
+if "risk_scoring" not in sys.modules:
+    risk_scoring = types.ModuleType("risk_scoring")
+    risk_scoring.risk_score = types.ModuleType("risk_scoring.risk_score")
+
+    def calculate_risk_score(static, dynamic):  # type: ignore[unused-argument]
+        return 0.0
+
+    risk_scoring.risk_score.calculate_risk_score = calculate_risk_score
+    sys.modules["risk_scoring"] = risk_scoring
+    sys.modules["risk_scoring.risk_score"] = risk_scoring.risk_score

--- a/tests/test_device_discovery.py
+++ b/tests/test_device_discovery.py
@@ -1,0 +1,37 @@
+from rotterdam.android.devices import discovery
+
+
+def test_list_detailed_devices_stub(monkeypatch):
+    """Stub ADB interaction and ensure device info is parsed."""
+    sample_output = "emulator-5554 device product:sdk_gphone_x86 transport_id:1"
+
+    def fake_check() -> str:
+        return sample_output
+
+    def fake_get_props(serial: str):
+        return {
+            "ro.product.manufacturer": "Google",
+            "ro.product.model": "sdk_gphone_x86",
+            "ro.build.version.release": "11",
+            "ro.build.version.sdk": "30",
+            "ro.product.cpu.abi": "x86",
+            "ro.board.platform": "generic_x86",
+            "ro.hardware": "ranchu",
+            "ro.build.tags": "test-keys",
+            "ro.build.type": "userdebug",
+            "ro.debuggable": "1",
+            "ro.secure": "0",
+            "ro.build.fingerprint": "fp",
+        }
+
+    monkeypatch.setattr(discovery, "check_connected_devices", fake_check)
+    monkeypatch.setattr(discovery, "get_props", fake_get_props)
+    monkeypatch.setattr(discovery, "_infer_is_emulator", lambda s, p, m: True)
+    monkeypatch.setattr(discovery, "_infer_connection_kind", lambda s, m: "usb")
+    monkeypatch.setattr(discovery, "_infer_root_status", lambda p: False)
+    monkeypatch.setattr(discovery, "_short_fingerprint", lambda fp: "shortfp")
+
+    devices = discovery.list_detailed_devices()
+    assert devices and devices[0]["serial"] == "emulator-5554"
+    assert devices[0]["manufacturer"] == "Google"
+    assert devices[0]["type"] == "emulator"

--- a/tests/test_display_table.py
+++ b/tests/test_display_table.py
@@ -1,0 +1,9 @@
+from utils.display_utils.table import print_table
+
+
+def test_table_ascii_snapshot(capsys):
+    rows = [[1, "alpha"], [2, "beta"]]
+    print_table(rows, headers=["id", "name"], max_width=40)
+    out = capsys.readouterr().out.strip().splitlines()
+    out = "\n".join(line.rstrip() for line in out)
+    assert out == "id | name\n----------\n1  | alpha\n2  | beta"

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+def test_healthz_endpoint():
+    """Ensure the liveness endpoint responds."""
+    with TestClient(app) as client:
+        resp = client.get("/_healthz")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}

--- a/tests/test_manifest_extractor.py
+++ b/tests/test_manifest_extractor.py
@@ -1,0 +1,17 @@
+import pytest
+from rotterdam.android.analysis.static.extractors.manifest import extract_permissions
+
+
+@pytest.fixture
+def minimal_manifest() -> str:
+    return (
+        "<manifest xmlns:android='http://schemas.android.com/apk/res/android'>"
+        "<uses-permission android:name='android.permission.INTERNET'/>"
+        "<application/>"
+        "</manifest>"
+    )
+
+
+def test_extract_permissions(minimal_manifest):
+    perms = extract_permissions(minimal_manifest)
+    assert perms == ["android.permission.INTERNET"]


### PR DESCRIPTION
## Summary
- test FastAPI /_healthz endpoint
- stub Android device discovery for unit testing without ADB
- snapshot test for ASCII table rendering
- minimal manifest extractor test

## Testing
- `pre-commit run --files tests/conftest.py tests/test_healthz.py tests/test_device_discovery.py tests/test_display_table.py tests/test_manifest_extractor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a679baf2f48327af264e14a89c7ebe