### PR TITLE
Add utils package init files and expand isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ target-version = ["py312"]
 
 [tool.isort]
 profile = "black"
-known_first_party = ["server", "cli"]
+known_first_party = ["server","cli","utils","core","platform","analysis","storage","orchestrator","workers"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Shared utility subpackages."""
+
+from . import display_utils, logging_utils, reporting_utils
+
+__all__ = [
+    "display_utils",
+    "logging_utils",
+    "reporting_utils",
+]

--- a/utils/display_utils/__init__.py
+++ b/utils/display_utils/__init__.py
@@ -1,0 +1,40 @@
+"""Helpers for formatted terminal output."""
+
+from .display import (
+    banner,
+    clear_screen,
+    divider,
+    header,
+    print_app_banner,
+    print_bullets,
+    print_kv,
+    print_menu,
+    print_section,
+    print_table,
+    prompt_choice,
+    render_menu,
+    term_width,
+    wrap_text,
+)
+from .status import fail, good, info, warn
+
+__all__ = [
+    "banner",
+    "clear_screen",
+    "divider",
+    "header",
+    "print_app_banner",
+    "print_bullets",
+    "print_kv",
+    "print_menu",
+    "print_section",
+    "prompt_choice",
+    "render_menu",
+    "term_width",
+    "wrap_text",
+    "print_table",
+    "info",
+    "good",
+    "warn",
+    "fail",
+]

--- a/utils/logging_utils/__init__.py
+++ b/utils/logging_utils/__init__.py
@@ -1,0 +1,5 @@
+"""Structured logging helpers."""
+
+from .logging_config import StructuredLogger, get_logger, log_context
+
+__all__ = ["StructuredLogger", "get_logger", "log_context"]

--- a/utils/reporting_utils/__init__.py
+++ b/utils/reporting_utils/__init__.py
@@ -1,0 +1,39 @@
+"""Risk report helpers."""
+
+from .ieee import (
+    format_device_inventory,
+    format_evidence_log,
+    format_package_inventory,
+    format_risk_summary,
+    format_yara_matches,
+    ieee_table,
+    major_heading,
+    subsection_heading,
+)
+from .report_utils import fetch_history, fetch_latest, generate_report
+from .risk_reporting import (
+    create_risk_report,
+    get_latest_report,
+    get_risk_history,
+    history,
+    report_risk,
+)
+
+__all__ = [
+    "format_device_inventory",
+    "format_evidence_log",
+    "format_package_inventory",
+    "format_risk_summary",
+    "format_yara_matches",
+    "ieee_table",
+    "major_heading",
+    "subsection_heading",
+    "fetch_history",
+    "fetch_latest",
+    "generate_report",
+    "create_risk_report",
+    "get_latest_report",
+    "get_risk_history",
+    "history",
+    "report_risk",
+]


### PR DESCRIPTION
## Summary
- add __init__ modules for utils packages with explicit exports
- broaden isort known first-party modules
- confirm .gitignore already excludes .venv/ and .pytest_cache

## Testing
- `pre-commit run --files utils/__init__.py utils/display_utils/__init__.py utils/logging_utils/__init__.py utils/reporting_utils/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a679b7c23c83278549570c319d43c8