### PR TITLE
feat: add centralized settings package

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ development.
 
 A lightweight REST API can be launched to submit APKs for analysis and
 retrieve risk reports. The web server's host, port, log level and browser
-behaviour all come from `server/serv_config.py`, which also honours
-environment overrides (`APP_HOST`, `APP_PORT`, `UVICORN_LOG_LEVEL`,
-`OPEN_BROWSER`). The `run.sh` helper sources these values so the CLI and server
-share a single source of truth. Set a custom API key via `ROTTERDAM_API_KEY`
-and start the server via the CLI:
+behaviour are provided by the centralized [`settings`](settings/) package
+(`settings.get_settings`) which honours environment overrides (`APP_HOST`,
+`APP_PORT`, `UVICORN_LOG_LEVEL`, `OPEN_BROWSER`). The `run.sh` helper sources
+these values so the CLI and server share a single source of truth. See
+[`docs/environment.md`](docs/environment.md) for a full list of variables. Set a
+custom API key via `ROTTERDAM_API_KEY` and start the server via the CLI:
 
 ```bash
 export ROTTERDAM_API_KEY="my-strong-key"  # default "secret" will trigger a warning

--- a/cli/actions/__main__.py
+++ b/cli/actions/__main__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import argparse
 
-from server import serv_config as cfg
+from settings import get_settings
+
 from . import list_installed_packages, run_server
 
 
@@ -13,17 +14,16 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Rotterdam utilities")
     sub = parser.add_subparsers(dest="cmd")
 
+    s = get_settings()
     p_serve = sub.add_parser("serve", help="start API server")
-    p_serve.add_argument("--host", default=cfg.HOST)
-    p_serve.add_argument("--port", type=int, default=cfg.PORT)
+    p_serve.add_argument("--host", default=s.host)
+    p_serve.add_argument("--port", type=int, default=s.port)
 
     p_list = sub.add_parser("list-packages", help="list installed packages")
     p_list.add_argument("serial", help="device serial")
     p_list.add_argument("--user", action="store_true", help="show only user apps")
     p_list.add_argument("--system", action="store_true", help="show only system apps")
-    p_list.add_argument(
-        "--high-value", action="store_true", help="show only high-value apps"
-    )
+    p_list.add_argument("--high-value", action="store_true", help="show only high-value apps")
     p_list.add_argument("--regex", help="filter packages by regex")
     p_list.add_argument("--csv", help="export results to CSV at path")
     p_list.add_argument("--json", dest="json_path", help="export results to JSON")
@@ -49,4 +49,3 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()
-

--- a/cli/actions/server.py
+++ b/cli/actions/server.py
@@ -1,30 +1,25 @@
 from __future__ import annotations
+
 import socket
 import threading
 import webbrowser
 
 from sqlalchemy import text
 
-from utils.display_utils import display
-from storage.repository import (
-    session_scope,
-    DATABASE_URL,
-    ping_db,
-)
-
-from server import serv_config as cfg
 from server.serve import serve
-from .utils import action_context as _action_context, logger
+from settings import get_settings
+from storage.repository import DATABASE_URL, ping_db, session_scope
+from utils.display_utils import display
+
+from .utils import action_context as _action_context
+from .utils import logger
 
 
 def _fetch_recent_analyses(conn, limit: int = 10) -> list[list[str | int | None]]:
     """Return the most recent analyses records for display."""
     try:
         res = conn.execute(
-            text(
-                "SELECT package_name, score, status "
-                "FROM analyses ORDER BY id DESC LIMIT :lim"
-            ),
+            text("SELECT package_name, score, status " "FROM analyses ORDER BY id DESC LIMIT :lim"),
             {"lim": limit},
         )
         return [[row[0], row[1], row[2]] for row in res]
@@ -71,7 +66,7 @@ def show_database_status() -> None:
         print("No analysis records found.")
 
 
-def launch_web_app(host: str = cfg.HOST, port: int = cfg.PORT) -> None:
+def launch_web_app(host: str = get_settings().host, port: int = get_settings().port) -> None:
     """Launch the web interface, starting the server if needed."""
     logger.info("launch_web_app", extra={"host": host, "port": port})
 
@@ -93,8 +88,7 @@ def launch_web_app(host: str = cfg.HOST, port: int = cfg.PORT) -> None:
         webbrowser.open(f"http://{host}:{port}")
 
 
-def run_server(host: str = cfg.HOST, port: int = cfg.PORT) -> None:
+def run_server(host: str = get_settings().host, port: int = get_settings().port) -> None:
     """Start the API server using centralized config."""
     with _action_context("run_server"):
         serve(host=host, port=port, open_browser=False)
-

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,15 @@
+# Environment Configuration
+
+Rotterdam reads configuration from environment variables using the
+[`pydantic-settings`](https://pydantic-docs.helpmanual.io/latest/usage/pydantic_settings/)
+package. Defaults are defined in `settings/app.py` and used throughout
+the project.
+
+| Variable            | Default     | Description                                       |
+|---------------------|-------------|---------------------------------------------------|
+| `APP_HOST`          | `127.0.0.1` | Host interface for the web server                 |
+| `APP_PORT`          | `8765`      | Port for the web server                           |
+| `UVICORN_LOG_LEVEL` | `info`      | Log level for Uvicorn                             |
+| `OPEN_BROWSER`      | `true`      | Whether to open a browser when server starts      |
+
+These settings are accessed via `settings.get_settings()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ httpx==0.28.1
 jmespath==1.0.1
 mysql-connector-python>=9.0.0
 pydantic==2.11.7
+pydantic-settings==2.9.1
 pyopenssl>=25,<26
 pytest==8.4.1
 pytest-cov==6.2.1

--- a/run.sh
+++ b/run.sh
@@ -24,12 +24,13 @@ SCRIPT_PATH="$(resolve_path "$0")"
 ROOT_DIR="$(dirname "$SCRIPT_PATH")"
 cd "$ROOT_DIR"
 
-# Load default host/port from server/serv_config.py; fallback if import fails
+# Load default host/port from settings package; fallback if import fails
 read_defaults() {
   python3 - <<'PY' || true
 try:
-    from server.serv_config import HOST, PORT
-    print(f"{HOST} {PORT}")
+    from settings import get_settings
+    s = get_settings()
+    print(f"{s.host} {s.port}")
 except Exception:
     print("127.0.0.1 8000")
 PY

--- a/server/serve.py
+++ b/server/serve.py
@@ -9,8 +9,7 @@ from typing import Optional
 
 import uvicorn
 
-# Centralized config (host/port/log level, etc.)
-from server import serv_config as cfg
+from settings import get_settings
 
 
 def _wait_for_port(host: str, port: int, timeout: float = 5.0) -> bool:
@@ -56,16 +55,17 @@ def serve(
 
     Usage (from menu option [5]):
         from server.serve import serve
-        serve()  # uses server/serv_config.py (env overrides honored)
+        serve()  # uses settings.get_settings() (env overrides honored)
 
     You can also override per-call:
         serve(port=8765, reload=True, open_browser=False)
     """
+    s = get_settings()
     # Merge call-time overrides with centralized config
-    h = cfg.HOST if host is None else host
-    p = cfg.PORT if port is None else int(port)
-    lvl = cfg.LOG_LEVEL if log_level is None else str(log_level).lower()
-    ob = cfg.OPEN_BROWSER if open_browser is None else bool(open_browser)
+    h = s.host if host is None else host
+    p = s.port if port is None else int(port)
+    lvl = s.log_level if log_level is None else str(log_level).lower()
+    ob = s.open_browser if open_browser is None else bool(open_browser)
 
     # Reload/worker defaults (safe for dev)
     use_reload = bool(reload) if reload is not None else False

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,0 +1,10 @@
+"""Application configuration powered by pydantic-settings.
+
+This package centralizes environment-driven settings and path
+configuration so modules across the project can share defaults and
+behaviour.
+"""
+
+from .app import AppSettings, get_settings
+
+__all__ = ["AppSettings", "get_settings"]

--- a/settings/app.py
+++ b/settings/app.py
@@ -1,0 +1,35 @@
+"""Core application settings loaded from environment variables.
+
+This module uses :class:`pydantic_settings.BaseSettings` to provide a
+single source of truth for configuration. Existing modules can
+instantiate :func:`get_settings` and access fields instead of reading
+`os.environ` directly.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from server import serv_config as legacy
+
+
+class AppSettings(BaseSettings):
+    """Runtime configuration for the Rotterdam application."""
+
+    host: str = Field(legacy.DEFAULT_HOST, validation_alias="APP_HOST")
+    port: int = Field(legacy.DEFAULT_PORT, validation_alias="APP_PORT")
+    log_level: legacy.LogLevel = Field(
+        legacy.DEFAULT_LOG_LEVEL, validation_alias="UVICORN_LOG_LEVEL"
+    )
+    open_browser: bool = Field(True, validation_alias="OPEN_BROWSER")
+
+    model_config = SettingsConfigDict(case_sensitive=False)
+
+
+@lru_cache
+def get_settings() -> AppSettings:
+    """Return cached application settings using environment variables."""
+    return AppSettings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,32 @@
+from server import serv_config as legacy
+from settings import get_settings
+
+
+def clear_cache():
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_defaults(monkeypatch):
+    monkeypatch.delenv("APP_HOST", raising=False)
+    monkeypatch.delenv("APP_PORT", raising=False)
+    monkeypatch.delenv("UVICORN_LOG_LEVEL", raising=False)
+    monkeypatch.delenv("OPEN_BROWSER", raising=False)
+    clear_cache()
+    s = get_settings()
+    assert s.host == legacy.DEFAULT_HOST
+    assert s.port == legacy.DEFAULT_PORT
+    assert s.log_level == legacy.DEFAULT_LOG_LEVEL
+    assert s.open_browser is True
+
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv("APP_HOST", "0.0.0.0")
+    monkeypatch.setenv("APP_PORT", "9999")
+    monkeypatch.setenv("UVICORN_LOG_LEVEL", "debug")
+    monkeypatch.setenv("OPEN_BROWSER", "false")
+    clear_cache()
+    s = get_settings()
+    assert s.host == "0.0.0.0"
+    assert s.port == 9999
+    assert s.log_level == "debug"
+    assert s.open_browser is False


### PR DESCRIPTION
## Summary
- add `settings` package using pydantic-settings to unify configuration
- update run.sh to load default host and port from new settings
- document environment variables and defaults
- migrate server and CLI modules to use settings and cache lookups
- cover default and env override behavior with tests

## Testing
- `pre-commit run --files settings/app.py settings/__init__.py server/serve.py cli/actions/__main__.py cli/actions/server.py tests/test_settings.py README.md`
- `PYTHONPATH=. pytest`
- `./run.sh --check`


------
https://chatgpt.com/codex/tasks/task_e_68a679b9bef483279418446f708fae1f