### PR TITLE
Add file path comments to script shebangs

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,3 +1,4 @@
+# File: analysis/__init__.py
 """Static APK analysis helpers."""
 
 from __future__ import annotations

--- a/analysis/androguard_utils.py
+++ b/analysis/androguard_utils.py
@@ -1,2 +1,3 @@
+# File: analysis/androguard_utils.py
 from rotterdam.android.analysis.static.adapters.androguard import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/cert_analysis.py
+++ b/analysis/cert_analysis.py
@@ -1,2 +1,3 @@
+# File: analysis/cert_analysis.py
 from rotterdam.android.analysis.static.extractors.crypto import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/dependencies.py
+++ b/analysis/dependencies.py
@@ -1,2 +1,3 @@
+# File: analysis/dependencies.py
 from rotterdam.android.analysis.static.extractors.dependencies import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/diff.py
+++ b/analysis/diff.py
@@ -1,2 +1,3 @@
+# File: analysis/diff.py
 from rotterdam.android.analysis.static.diff import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/manifest.py
+++ b/analysis/manifest.py
@@ -1,2 +1,3 @@
+# File: analysis/manifest.py
 from rotterdam.android.analysis.static.extractors.manifest import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/ml_model.py
+++ b/analysis/ml_model.py
@@ -1,3 +1,4 @@
+# File: analysis/ml_model.py
 """Convenience wrapper for the Android static analysis ML model.
 
 This module re-exports :func:`predict_malicious` so callers can simply

--- a/analysis/network_security.py
+++ b/analysis/network_security.py
@@ -1,2 +1,3 @@
+# File: analysis/network_security.py
 from rotterdam.android.analysis.static.extractors.network import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/permissions.py
+++ b/analysis/permissions.py
@@ -1,2 +1,3 @@
+# File: analysis/permissions.py
 from rotterdam.android.analysis.static.extractors.permissions import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/report.py
+++ b/analysis/report.py
@@ -1,2 +1,3 @@
+# File: analysis/report.py
 from rotterdam.android.analysis.static.report.writer import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/risk_scoring/__init__.py
+++ b/analysis/risk_scoring/__init__.py
@@ -1,3 +1,4 @@
+# File: analysis/risk_scoring/__init__.py
 """Risk scoring utilities for analysis pipelines."""
 
 from rotterdam.android.analysis.static.scoring.risk_score import (

--- a/analysis/risk_scoring/risk_score.py
+++ b/analysis/risk_scoring/risk_score.py
@@ -1,2 +1,3 @@
+# File: analysis/risk_scoring/risk_score.py
 from rotterdam.android.analysis.static.scoring.risk_score import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/rules_engine.py
+++ b/analysis/rules_engine.py
@@ -1,2 +1,3 @@
+# File: analysis/rules_engine.py
 from rotterdam.android.analysis.static.rules.engine import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/secrets.py
+++ b/analysis/secrets.py
@@ -1,3 +1,4 @@
+# File: analysis/secrets.py
 import sys
 from importlib import import_module
 

--- a/analysis/signature.py
+++ b/analysis/signature.py
@@ -1,2 +1,3 @@
+# File: analysis/signature.py
 from rotterdam.android.analysis.static.extractors.signing import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/static.py
+++ b/analysis/static.py
@@ -1,2 +1,3 @@
+# File: analysis/static.py
 from rotterdam.android.analysis.static.pipeline import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/analysis/yara_scan.py
+++ b/analysis/yara_scan.py
@@ -1,2 +1,3 @@
+# File: analysis/yara_scan.py
 from rotterdam.android.analysis.static.yara_scan import *  # noqa
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/app_config/app_config.py
+++ b/app_config/app_config.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: app_config/app_config.py
 # config.py
 """Central configuration for Android Tool.
 

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: core/helpers.py
 # helpers.py
 """
 General-purpose helper functions for Android Tool.

--- a/platform/android/analysis/dynamic/network.py
+++ b/platform/android/analysis/dynamic/network.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/analysis/dynamic/network.py
 """Utility for capturing and summarizing network traffic from an emulator.
 
 This module provides a light abstraction around ``tcpdump`` or ``mitmproxy``

--- a/platform/android/analysis/dynamic/permission_monitor.py
+++ b/platform/android/analysis/dynamic/permission_monitor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/analysis/dynamic/permission_monitor.py
 """Utility to monitor Android runtime permission accesses via ``adb``.
 
 This module hooks into ``adb shell dumpsys appops`` (or ``appops`` directly)

--- a/platform/android/devices/adb.py
+++ b/platform/android/devices/adb.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/adb.py
 """Shared helpers for invoking ``adb`` commands."""
 
 from __future__ import annotations

--- a/platform/android/devices/apk.py
+++ b/platform/android/devices/apk.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/apk.py
 """Utilities to pull APKs from a connected device."""
 
 from __future__ import annotations

--- a/platform/android/devices/discovery.py
+++ b/platform/android/devices/discovery.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/discovery.py
 # discovery.py
 """Helpers for discovering and enriching connected Android devices via ADB."""
 

--- a/platform/android/devices/packages.py
+++ b/platform/android/devices/packages.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/packages.py
 """Scan installed apps on a device for dangerous permissions."""
 
 from __future__ import annotations

--- a/platform/android/devices/processes.py
+++ b/platform/android/devices/processes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/processes.py
 """List running processes on a device via ADB (robust across Android ps variants)."""
 
 from __future__ import annotations

--- a/platform/android/devices/props.py
+++ b/platform/android/devices/props.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/props.py
 """Helpers for retrieving and interpreting device properties."""
 
 from __future__ import annotations

--- a/platform/android/devices/selection.py
+++ b/platform/android/devices/selection.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: platform/android/devices/selection.py
 # selection.py
 """
 Allows users to list connected devices and select one to connect to,

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# File: run.sh
 set -euo pipefail
 
 OK="[OK]"; WARN="[!]"; ERR="[X]"; INF="[*]"

--- a/scripts/clean-project.sh
+++ b/scripts/clean-project.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# File: scripts/clean-project.sh
 # clean.sh — minimal Fedora-only cleaner for the Rotterdam repo
 
 set -euo pipefail

--- a/scripts/install-aapt2.sh
+++ b/scripts/install-aapt2.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# File: scripts/install-aapt2.sh
 # install-aapt2.sh — Fedora-only one-shot installer for aapt2 via Android SDK build-tools
 
 set -euo pipefail

--- a/scripts/install-apktool.sh
+++ b/scripts/install-apktool.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# File: scripts/install-apktool.sh
 set -euo pipefail
 
 log(){ echo "[*] $*"; } ; good(){ echo "[OK] $*"; } ; fail(){ echo "[X] $*"; exit 1; }

--- a/scripts/install-precommit.sh
+++ b/scripts/install-precommit.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+# File: scripts/install-precommit.sh
 set -euo pipefail
 pre-commit install

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# File: setup.sh
 set -euo pipefail
 
 # --- Paths ---

--- a/utils/display_utils/display.py
+++ b/utils/display_utils/display.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: utils/display_utils/display.py
 # display.py
 """
 General display utilities for Android Tool.

--- a/utils/display_utils/table.py
+++ b/utils/display_utils/table.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# File: utils/display_utils/table.py
 # table.py
 """
 Table display utilities for Android Tool.


### PR DESCRIPTION
## Summary
- add `# File: <path>` comments after shebang lines for all Python and shell scripts
- include file path comments at top of `analysis` modules for consistent traceability

## Testing
- `python -m pre_commit run --files analysis/__init__.py analysis/androguard_utils.py analysis/cert_analysis.py analysis/dependencies.py analysis/diff.py analysis/manifest.py analysis/ml_model.py analysis/network_security.py analysis/permissions.py analysis/report.py analysis/rules_engine.py analysis/secrets.py analysis/signature.py analysis/static.py analysis/yara_scan.py analysis/risk_scoring/__init__.py analysis/risk_scoring/risk_score.py` *(fails: The python version 313 is not supported)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'utils.reporting_utils.ieee')*

------
https://chatgpt.com/codex/tasks/task_e_68a683fc78c083278b24db7fe9c36b42