### PR TITLE
Add display configuration helper for status output

### DIFF
--- a/utils/display_utils/__init__.py
+++ b/utils/display_utils/__init__.py
@@ -17,6 +17,7 @@ from .display import (
     wrap_text,
 )
 from .status import fail, good, info, warn
+from . import config
 
 __all__ = [
     "banner",
@@ -37,4 +38,5 @@ __all__ = [
     "good",
     "warn",
     "fail",
+    "config",
 ]

--- a/utils/display_utils/config.py
+++ b/utils/display_utils/config.py
@@ -1,0 +1,10 @@
+"""Configuration helpers for display utilities.
+
+This module re-exports display-related settings from the global
+:mod:`app_config` package so modules in :mod:`utils.display_utils` can
+access them without importing the full application configuration.
+"""
+
+from app_config.app_config import USE_COLOR, ts
+
+__all__ = ["USE_COLOR", "ts"]

--- a/utils/display_utils/status.py
+++ b/utils/display_utils/status.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from typing import TextIO
 
+from .config import USE_COLOR, ts as _ts
+
 OK = "[OK]"
 INF = "[*]"
 WARN = "[!]"
@@ -21,11 +23,10 @@ RESET = "\033[0m"
 
 def _emit(prefix: str, msg: str, *, ts: bool = False, stream: TextIO = sys.stdout) -> None:
     """Internal helper to print a prefixed message."""
-    from . import config
 
-    color = COLOR_PREFIX.get(prefix, "") if config.USE_COLOR else ""
+    color = COLOR_PREFIX.get(prefix, "") if USE_COLOR else ""
     pre = f"{color}{prefix}{RESET}" if color else prefix
-    stamp = f"{config.ts()} | " if ts else ""
+    stamp = f"{_ts()} | " if ts else ""
     print(f"{pre} {stamp}{msg}", file=stream)
 
 


### PR DESCRIPTION
## Summary
- add `config` module for display utilities that exposes `USE_COLOR` and `ts`
- update `status` emitter to use new configuration source
- re-export display config via `utils.display_utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.reporting_utils.ieee')*

------
https://chatgpt.com/codex/tasks/task_e_68a6897ecb808327aeae57186ca61c29