### PR TITLE
refactor: use reporting_utils

### DIFF
--- a/platform/android/analysis/static/pipeline.py
+++ b/platform/android/analysis/static/pipeline.py
@@ -51,7 +51,7 @@ except Exception:  # pragma: no cover
     analyze_certificates = None  # type: ignore[assignment]
 
 # Risk scoring
-import reporting
+from utils.reporting_utils import generate_report
 
 
 def analyze_apk(apk_path: str, outdir: str | Path | None = None) -> Path:
@@ -227,7 +227,7 @@ def analyze_apk(apk_path: str, outdir: str | Path | None = None) -> Path:
     dynamic_metrics: Dict[str, float] = {}
 
     # Risk scoring (merges static+dynamic and ML-derived metrics)
-    risk = reporting.generate(apk.stem, metrics, dynamic_metrics)
+    risk = generate_report(apk.stem, metrics, dynamic_metrics)
     (out / "risk_score.json").write_text(json.dumps(risk, indent=2))
 
     # Store a snapshot of key manifest data with a simple version tag

--- a/server/job_service.py
+++ b/server/job_service.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, field_validator
 
-import reporting
+from utils.reporting_utils import generate_report
 
 
 class JobRequest(BaseModel):
@@ -41,7 +41,7 @@ _jobs: Dict[str, Dict[str, Any]] = {}
 def _process_job(job_id: str, req: JobRequest) -> None:
     """Simulate job processing and populate the report."""
     time.sleep(0.5)
-    risk = reporting.generate("unknown", req.static_metrics, req.dynamic_metrics)
+    risk = generate_report("unknown", req.static_metrics, req.dynamic_metrics)
     _jobs[job_id]["report"] = {
         "status": "completed",
         "risk": risk,

--- a/server/routes.py
+++ b/server/routes.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from fastapi import APIRouter, File, HTTPException, Response, UploadFile, status
 from fastapi.responses import FileResponse
 
-import reporting
+from utils.reporting_utils import generate_report
 from orchestrator.scheduler import scheduler
 from storage.repository import ping_db
 
@@ -48,7 +48,7 @@ def _process_apk(apk_path: str) -> dict[str, str]:
     package_name = path.stem
 
     # Generate a risk report
-    result = reporting.generate(package_name)
+    result = generate_report(package_name)
 
     # Write JSON and HTML versions to a unique directory
     out_dir = _ANALYSIS_ROOT / uuid.uuid4().hex


### PR DESCRIPTION
## Summary
- import risk reporting helpers from `utils.reporting_utils`
- update server and Android pipeline to use `generate_report`

## Testing
- `pytest` *(fails: No module named 'utils.reporting_utils.ieee')*

------
https://chatgpt.com/codex/tasks/task_e_68a6897df2dc83279094e8cad746c8a3