### PR TITLE
Add note status display utility

### DIFF
--- a/utils/display_utils/__init__.py
+++ b/utils/display_utils/__init__.py
@@ -16,7 +16,7 @@ from .display import (
     term_width,
     wrap_text,
 )
-from .status import fail, good, info, warn
+from .status import error, fail, good, info, note, warn, warning
 
 __all__ = [
     "banner",
@@ -34,7 +34,10 @@ __all__ = [
     "wrap_text",
     "print_table",
     "info",
+    "note",
     "good",
     "warn",
+    "warning",
     "fail",
+    "error",
 ]

--- a/utils/display_utils/display.py
+++ b/utils/display_utils/display.py
@@ -20,7 +20,7 @@ from typing import Iterable, Sequence, Any, Optional, Callable, List
 
 from app_config import app_config
 from . import table as tables
-from .status import info, good, warn, fail
+from .status import error, fail, good, info, note, warn, warning
 
 # -----------------------------
 # Terminal / layout

--- a/utils/display_utils/status.py
+++ b/utils/display_utils/status.py
@@ -7,12 +7,14 @@ from typing import TextIO
 
 OK = "[OK]"
 INF = "[*]"
+NOTE = "[.]"
 WARN = "[!]"
 ERR = "[X]"
 
 COLOR_PREFIX = {
     OK: "\033[32m",
     INF: "\033[36m",
+    NOTE: "\033[36m",
     WARN: "\033[33m",
     ERR: "\033[31m",
 }
@@ -34,6 +36,11 @@ def info(msg: str, *, ts: bool = False) -> None:
     _emit(INF, msg, ts=ts, stream=sys.stdout)
 
 
+def note(msg: str, *, ts: bool = False) -> None:
+    """Print a secondary informational status line."""
+    _emit(NOTE, msg, ts=ts, stream=sys.stdout)
+
+
 def good(msg: str, *, ts: bool = False) -> None:
     """Print a success status line."""
     _emit(OK, msg, ts=ts, stream=sys.stdout)
@@ -47,3 +54,13 @@ def warn(msg: str, *, ts: bool = False) -> None:
 def fail(msg: str, *, ts: bool = False) -> None:
     """Print an error status line."""
     _emit(ERR, msg, ts=ts, stream=sys.stderr)
+
+
+def warning(msg: str, *, ts: bool = False) -> None:
+    """Alias for :func:`warn` for clearer call sites."""
+    warn(msg, ts=ts)
+
+
+def error(msg: str, *, ts: bool = False) -> None:
+    """Alias for :func:`fail` for clearer call sites."""
+    fail(msg, ts=ts)


### PR DESCRIPTION
## Summary
- add `warning` and `error` display helpers alongside existing `note`
- export new helpers through display utilities package

## Testing
- `pre-commit run --files utils/display_utils/status.py utils/display_utils/__init__.py utils/display_utils/display.py` *(fails: Invalid value for '--target-version': 'py313' is not supported)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils.reporting_utils.ieee')*

------
https://chatgpt.com/codex/tasks/task_e_68a6897fe2ec83278186898916cc45b0