### PR TITLE
Add missing platform package initializer

### DIFF
--- a/platform/__init__.py
+++ b/platform/__init__.py
@@ -1,0 +1,3 @@
+"""Platform-specific implementations for Rotterdam."""
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- Ensure the repository's `platform` directory is treated as a package
- Fix ModuleNotFoundError when importing device modules

## Testing
- `pytest -q` (fails: ImportError cannot import name 'generate_report' from 'utils.reporting_utils')


------
https://chatgpt.com/codex/tasks/task_e_68a6792bdf8c8327a6267e5a9d377872