### PR TITLE
Refine database utilities and add connection tester

### DIFF
--- a/database/db_engine.py
+++ b/database/db_engine.py
@@ -14,18 +14,29 @@ import DbEngine and build repository-like modules on top of it.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 import time
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
-from mysql.connector import Error
-from mysql.connector import errorcode
-from mysql.connector.cursor import MySQLCursor
+from mysql.connector import Error, errorcode
 from mysql.connector.connection import MySQLConnection
+from mysql.connector.cursor import MySQLCursor
 
 from database.db_core import DatabaseCore
 
 Params = Union[Tuple[Any, ...], Dict[str, Any]]
+T = TypeVar("T")
 
 
 class DbEngine:
@@ -93,7 +104,9 @@ class DbEngine:
         Commits on success, rolls back on exception.
         """
         with self._core.connection() as conn:
-            cur = conn.cursor(dictionary=(self._default_dict_rows if dict_rows is None else dict_rows))
+            cur = conn.cursor(
+                dictionary=(self._default_dict_rows if dict_rows is None else dict_rows)
+            )
             try:
                 yield cur
                 conn.commit()
@@ -128,7 +141,9 @@ class DbEngine:
         only for data-changing statements when outside a transaction context.
         """
         with self._core.connection() as conn:
-            cur = conn.cursor(dictionary=(self._default_dict_rows if dict_rows is None else dict_rows))
+            cur = conn.cursor(
+                dictionary=(self._default_dict_rows if dict_rows is None else dict_rows)
+            )
             try:
                 cur.execute(sql, params)
                 affected = cur.rowcount
@@ -156,7 +171,9 @@ class DbEngine:
         Execute a statement for multiple parameter sets. Returns rowcount.
         """
         with self._core.connection() as conn:
-            cur = conn.cursor(dictionary=(self._default_dict_rows if dict_rows is None else dict_rows))
+            cur = conn.cursor(
+                dictionary=(self._default_dict_rows if dict_rows is None else dict_rows)
+            )
             try:
                 cur.executemany(sql, list(seq_of_params))
                 affected = cur.rowcount
@@ -229,17 +246,28 @@ class DbEngine:
 
     def with_retry(
         self,
-        fn,
+        fn: Callable[[], T],
         *,
         max_attempts: int = 3,
         backoff_sec: float = 0.25,
         transient_only: bool = True,
-    ):
+    ) -> T:
         """
         Run a callable with simple retry for transient MySQL errors.
-        Example:
-            result = engine.with_retry(lambda: engine.fetch_all("SELECT ..."))
+
+        Args:
+            fn: Zero-argument callable to execute.
+            max_attempts: Maximum number of attempts before failing.
+            backoff_sec: Initial backoff time between attempts.
+            transient_only: If True only retry known transient MySQL errors.
+
+        Returns:
+            The value returned by ``fn`` on success.
+
+        Raises:
+            Exception: The last captured exception after exhausting retries.
         """
+
         attempt = 0
         last_exc: Optional[Exception] = None
         transient_codes = {
@@ -254,18 +282,19 @@ class DbEngine:
                 return fn()
             except Error as e:
                 last_exc = e
-                if transient_only:
-                    if not hasattr(e, "errno") or e.errno not in transient_codes:
-                        break
-                time.sleep(backoff_sec * (2 ** attempt))
-                attempt += 1
+                if transient_only and getattr(e, "errno", None) not in transient_codes:
+                    break
             except Exception as e:
                 last_exc = e
                 break
 
-        if last_exc:
+            time.sleep(backoff_sec * (2**attempt))
+            attempt += 1
+
+        if last_exc is not None:
             raise last_exc
-        return None
+
+        raise RuntimeError("with_retry: function did not return a value")
 
 
 # -------------------------
@@ -285,6 +314,7 @@ _WRITE_PREFIXES = (
     "grant",
     "revoke",
 )
+
 
 def _is_write_statement(sql: str) -> bool:
     s = sql.lstrip().lower()

--- a/database/db_queries.py
+++ b/database/db_queries.py
@@ -1,0 +1,36 @@
+"""Common SQL helpers built on top of :mod:`database.db_engine`.
+
+This module exposes tiny wrappers around :class:`DbEngine` for queries that
+are handy during development or debugging. They avoid domain specific logic so
+that the helpers remain reusable across projects.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from database.db_engine import DbEngine
+
+
+def fetch_version(engine: DbEngine) -> Optional[str]:
+    """Return the database server version string.
+
+    Args:
+        engine: The :class:`DbEngine` instance to use.
+
+    Returns:
+        The version string if available, otherwise ``None``.
+    """
+
+    row = engine.fetch_one("SELECT VERSION() AS version", dict_rows=True)
+    return row.get("version") if row else None
+
+
+def list_tables(engine: DbEngine) -> List[str]:
+    """Return the list of tables in the current database schema."""
+
+    rows = engine.fetch_all("SHOW TABLES", dict_rows=False)
+    return [r[0] for r in rows]
+
+
+__all__ = ["fetch_version", "list_tables"]

--- a/test_database.py
+++ b/test_database.py
@@ -1,0 +1,47 @@
+"""Simple script to exercise the database layer.
+
+Run ``python test_database.py`` to attempt a connection using the settings in
+``database/db_config.py``. The script prints the database version and the list
+of available tables if a connection can be established.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Ensure stdlib modules take precedence over same-named local packages (e.g., "platform")
+sys.path.append(sys.path.pop(0))
+
+from mysql.connector import Error
+
+from database import db_queries
+from database.db_core import DatabaseCore
+from database.db_engine import DbEngine
+
+
+def main() -> None:
+    core = DatabaseCore.from_config()
+    engine = DbEngine(core, default_dict_rows=True)
+
+    try:
+        engine.init()
+    except Error as exc:  # pragma: no cover - diagnostic script
+        print(f"Failed to connect: {exc}")
+        return
+
+    try:
+        if not engine.ping():
+            print("Database ping failed")
+            return
+
+        version = db_queries.fetch_version(engine)
+        print(f"Database version: {version}")
+
+        tables = db_queries.list_tables(engine)
+        print(f"Tables ({len(tables)}): {tables}")
+    finally:
+        engine.shutdown()
+
+
+if __name__ == "__main__":  # pragma: no cover - diagnostic script
+    main()


### PR DESCRIPTION
## Summary
- enhance DbEngine with typed `with_retry` logic and clarify write detection
- add reusable query helpers for server version and table listing
- provide `test_database.py` diagnostic script for manual connection checks

## Testing
- `pre-commit run --files database/db_engine.py database/db_queries.py test_database.py`
- `pytest -q` *(fails: ImportError: cannot import name 'generate_report' from 'utils.reporting_utils')*
- `python test_database.py` *(fails: 2003 (HY000): Can't connect to MySQL server on 'localhost:3306')*

------
https://chatgpt.com/codex/tasks/task_e_68a69a738b5c8327a0dcee6eb9fc9c2b