### PR TITLE
Clarify database package configuration

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,7 @@
+"""Database package exposing core and engine helpers."""
+
+from .db_config import DB_CONFIG
+from .db_core import DatabaseCore
+from .db_engine import DbEngine
+
+__all__ = ["DB_CONFIG", "DatabaseCore", "DbEngine"]

--- a/database/db_config.py
+++ b/database/db_config.py
@@ -1,11 +1,23 @@
 # database/db_config.py
-"""
-Database configuration file.
+"""Database configuration constants used by :mod:`database`.
+
+The values are intentionally hard coded for a local development database. In a
+real application these would likely be loaded from environment variables or a
+configuration file, but keeping them inline makes the examples in this
+repository self‑contained and easy to understand.
 """
 
-DB_CONFIG = {
+from typing import Final, Dict
+
+
+DB_CONFIG: Final[Dict[str, object]] = {
     "host": "localhost",
     "user": "root",
     "password": "NewStrongPass!",
     "database": "mydatabase",
+    # Optional extras used by :func:`DatabaseCore.from_config`
+    "port": 3306,
+    "connection_timeout": 10,
 }
+
+__all__ = ["DB_CONFIG"]

--- a/database/db_core.py
+++ b/database/db_core.py
@@ -386,3 +386,15 @@ class DatabaseCore:
         """
         with self._provider.connection() as conn:
             yield conn
+
+    # Context manager sugar
+
+    def __enter__(self) -> "DatabaseCore":
+        """Connect on entry so ``with DatabaseCore(...)`` just works."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - thin wrapper
+        self.disconnect()
+        # Do not suppress exceptions
+        return False

--- a/database/db_engine.py
+++ b/database/db_engine.py
@@ -76,6 +76,17 @@ class DbEngine:
     def ping(self, reconnect: bool = True) -> bool:
         return self._core.ping(reconnect=reconnect)
 
+    # Context manager sugar
+
+    def __enter__(self) -> "DbEngine":
+        """Initialise the core on entry for ``with DbEngine(...)`` usage."""
+        self.init()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - thin wrapper
+        self.shutdown()
+        return False
+
     # -------------------------
     # Cursor and transaction contexts
     # -------------------------

--- a/test_database.py
+++ b/test_database.py
@@ -20,27 +20,21 @@ from database.db_engine import DbEngine
 
 
 def main() -> None:
-    core = DatabaseCore.from_config()
-    engine = DbEngine(core, default_dict_rows=True)
-
     try:
-        engine.init()
+        with DatabaseCore.from_config() as core:
+            with DbEngine(core, default_dict_rows=True) as engine:
+                if not engine.ping():
+                    print("Database ping failed")
+                    return
+
+                version = db_queries.fetch_version(engine)
+                print(f"Database version: {version}")
+
+                tables = db_queries.list_tables(engine)
+                print(f"Tables ({len(tables)}): {tables}")
     except Error as exc:  # pragma: no cover - diagnostic script
         print(f"Failed to connect: {exc}")
         return
-
-    try:
-        if not engine.ping():
-            print("Database ping failed")
-            return
-
-        version = db_queries.fetch_version(engine)
-        print(f"Database version: {version}")
-
-        tables = db_queries.list_tables(engine)
-        print(f"Tables ({len(tables)}): {tables}")
-    finally:
-        engine.shutdown()
 
 
 if __name__ == "__main__":  # pragma: no cover - diagnostic script


### PR DESCRIPTION
## Summary
- document and type the hard-coded database configuration, including port and timeout
- expose core database helpers from a new `database` package init
- add context manager support to `DatabaseCore` and `DbEngine` for easier lifecycle management
- update test script to use the new context managers

## Testing
- `pytest` *(fails: ImportError: cannot import name 'generate_report' from 'utils.reporting_utils')*
- `python test_database.py` *(fails to connect: 2003 (HY000): Can't connect to MySQL server on 'localhost:3306' (111))*

------
https://chatgpt.com/codex/tasks/task_e_68a69e5aaf6c83278b7cf191561fdf1f