### PR TITLE
Refine sandbox and static analysis imports

### DIFF
--- a/analysis/static_analysis/androguard_utils.py
+++ b/analysis/static_analysis/androguard_utils.py
@@ -1,3 +1,6 @@
-# File: analysis/androguard_utils.py
-from rotterdam.android.analysis.static.adapters.androguard import *  # noqa
-__all__ = [name for name in dir() if not name.startswith("_")]
+"""Lightweight Androguard helpers for static analysis."""
+
+from platform.android.analysis.static.adapters.androguard import summarize_apk
+
+__all__ = ["summarize_apk"]
+

--- a/analysis/static_analysis/cert_analysis.py
+++ b/analysis/static_analysis/cert_analysis.py
@@ -1,3 +1,6 @@
-# File: analysis/cert_analysis.py
-from rotterdam.android.analysis.static.extractors.crypto import *  # noqa
-__all__ = [name for name in dir() if not name.startswith("_")]
+"""Minimal certificate analysis shim."""
+
+from platform.android.analysis.static.extractors.crypto import analyze_certificates
+
+__all__ = ["analyze_certificates"]
+

--- a/analysis/static_analysis/manifest.py
+++ b/analysis/static_analysis/manifest.py
@@ -1,3 +1,22 @@
-# File: analysis/manifest.py
-from rotterdam.android.analysis.static.extractors.manifest import *  # noqa
-__all__ = [name for name in dir() if not name.startswith("_")]
+"""Manifest extraction helpers exposed to the CLI."""
+
+from platform.android.analysis.static.extractors.manifest import (
+    extract_app_flags,
+    extract_components,
+    extract_features,
+    extract_metadata,
+    extract_permission_details,
+    extract_permissions,
+    extract_sdk_info,
+)
+
+__all__ = [
+    "extract_permission_details",
+    "extract_permissions",
+    "extract_components",
+    "extract_sdk_info",
+    "extract_features",
+    "extract_app_flags",
+    "extract_metadata",
+]
+

--- a/analysis/static_analysis/permissions.py
+++ b/analysis/static_analysis/permissions.py
@@ -1,3 +1,9 @@
-# File: analysis/permissions.py
-from rotterdam.android.analysis.static.extractors.permissions import *  # noqa
-__all__ = [name for name in dir() if not name.startswith("_")]
+"""Permission analysis utilities."""
+
+from platform.android.analysis.static.extractors.permissions import (
+    DANGEROUS_PERMISSIONS,
+    categorize_permissions,
+)
+
+__all__ = ["categorize_permissions", "DANGEROUS_PERMISSIONS"]
+

--- a/analysis/static_analysis/static.py
+++ b/analysis/static_analysis/static.py
@@ -1,3 +1,6 @@
-# File: analysis/static.py
-from rotterdam.android.analysis.static.pipeline import *  # noqa
-__all__ = [name for name in dir() if not name.startswith("_")]
+"""Entry points for static APK analysis."""
+
+from platform.android.analysis.static.pipeline import analyze_apk
+
+__all__ = ["analyze_apk"]
+

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,4 +1,20 @@
-from rotterdam.android.analysis.dynamic import *  # noqa: F403
-from rotterdam.android.analysis.dynamic import __all__ as dynamic_all
+"""Public sandbox helpers used by the CLI."""
 
-__all__ = list(dynamic_all)
+from platform.android.analysis.dynamic import (
+    analyze_apk,
+    collect_permissions,
+    compute_runtime_metrics,
+    run_analysis,
+    run_sandbox,
+    sniff_network,
+)
+
+__all__ = [
+    "run_analysis",
+    "run_sandbox",
+    "collect_permissions",
+    "sniff_network",
+    "compute_runtime_metrics",
+    "analyze_apk",
+]
+

--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -1,1 +1,9 @@
-from rotterdam.android.analysis.dynamic.__main__ import *  # noqa
+"""Entry point for running sandbox analysis as a script."""
+
+from platform.android.analysis.dynamic.__main__ import main
+
+__all__ = ["main"]
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
+

--- a/sandbox/frida_loader.py
+++ b/sandbox/frida_loader.py
@@ -1,1 +1,9 @@
-from rotterdam.android.analysis.dynamic.frida_loader import *  # noqa
+"""Helpers for discovering and selecting Frida scripts."""
+
+from platform.android.analysis.dynamic.frida_loader import (
+    discover_scripts,
+    resolve_hooks,
+)
+
+__all__ = ["discover_scripts", "resolve_hooks"]
+

--- a/sandbox/frida_scripts/__init__.py
+++ b/sandbox/frida_scripts/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from importlib import import_module
 
-_module = import_module('rotterdam.android.analysis.dynamic.frida')
+_module = import_module('platform.android.analysis.dynamic.frida')
 sys.modules[__name__] = _module
 __all__ = getattr(_module, "__all__", [])

--- a/sandbox/instrumentation.py
+++ b/sandbox/instrumentation.py
@@ -1,1 +1,6 @@
-from rotterdam.android.analysis.dynamic.instrumentation import *  # noqa
+"""Frida instrumentation facade."""
+
+from platform.android.analysis.dynamic.instrumentation import FridaInstrumentation
+
+__all__ = ["FridaInstrumentation"]
+

--- a/sandbox/intel.py
+++ b/sandbox/intel.py
@@ -1,1 +1,18 @@
-from rotterdam.android.analysis.dynamic.intel import *  # noqa
+"""Threat intelligence helpers."""
+
+from platform.android.analysis.dynamic.intel import (
+    BAD_DOMAINS,
+    BAD_IPS,
+    load_feeds,
+    score_domain,
+    score_ip,
+)
+
+__all__ = [
+    "load_feeds",
+    "score_ip",
+    "score_domain",
+    "BAD_IPS",
+    "BAD_DOMAINS",
+]
+

--- a/sandbox/metrics.py
+++ b/sandbox/metrics.py
@@ -1,1 +1,6 @@
-from rotterdam.android.analysis.dynamic.metrics import *  # noqa
+"""Expose runtime metric aggregation helpers."""
+
+from platform.android.analysis.dynamic.metrics import compute_runtime_metrics
+
+__all__ = ["compute_runtime_metrics"]
+

--- a/sandbox/network.py
+++ b/sandbox/network.py
@@ -1,1 +1,11 @@
-from rotterdam.android.analysis.dynamic.network import *  # noqa
+"""Network capture helpers exposed for sandbox analysis."""
+
+from platform.android.analysis.dynamic.network import (
+    NetworkSniffer,
+    export_summary,
+    parse_pcap,
+    sniff_network,
+)
+
+__all__ = ["sniff_network", "NetworkSniffer", "parse_pcap", "export_summary"]
+

--- a/sandbox/permission_monitor.py
+++ b/sandbox/permission_monitor.py
@@ -1,13 +1,13 @@
 """Facade for permission monitoring utilities.
 
 This module wraps select helpers from
-:mod:`rotterdam.android.analysis.dynamic.permission_monitor` so that tests can
+:mod:`platform.android.analysis.dynamic.permission_monitor` so that tests can
 patch internal helpers like :func:`_run_shell`.
 """
 from __future__ import annotations
 
-import rotterdam.android.analysis.dynamic.permission_monitor as _impl
-from rotterdam.android.analysis.dynamic.permission_monitor import PermissionAccess
+import platform.android.analysis.dynamic.permission_monitor as _impl
+from platform.android.analysis.dynamic.permission_monitor import PermissionAccess
 
 
 def _run_shell(cmd: list[str]) -> str:
@@ -34,5 +34,5 @@ def collect_permissions(apk_path: str) -> list[str]:
     return _impl.collect_permissions(apk_path)
 
 
-__all__ = ["collect_permissions", "PermissionMonitor", "PermissionAccess", "_run_shell"]
+__all__ = ["collect_permissions"]
 

--- a/sandbox/runner.py
+++ b/sandbox/runner.py
@@ -1,1 +1,6 @@
-from rotterdam.android.analysis.dynamic.runner import *  # noqa
+"""Sandbox runner entry point."""
+
+from platform.android.analysis.dynamic.runner import run_sandbox
+
+__all__ = ["run_sandbox"]
+

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -1,1 +1,6 @@
-from rotterdam.android.analysis.dynamic.runtime import *  # noqa
+"""High-level sandbox analysis wrapper."""
+
+from platform.android.analysis.dynamic.runtime import run_analysis
+
+__all__ = ["run_analysis"]
+

--- a/sandbox/ui_driver.py
+++ b/sandbox/ui_driver.py
@@ -1,1 +1,6 @@
-from rotterdam.android.analysis.dynamic.ui_driver import *  # noqa
+"""Expose deterministic UI exploration helpers."""
+
+from platform.android.analysis.dynamic.ui_driver import run_monkey
+
+__all__ = ["run_monkey"]
+


### PR DESCRIPTION
## Summary
- replace `rotterdam.android` wildcard imports with explicit `platform.android` functions in static analysis and sandbox modules
- expose only CLI-facing helpers via `__all__`
- route sandbox utilities through local implementations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a4753bbc8327abec5f1d57284686