### PR TITLE
Add tool wrappers for adb, apktool, and androguard

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -89,3 +89,7 @@ except Exception:
     predict_malicious = None  # type: ignore[assignment]
 else:
     __all__.append("predict_malicious")
+
+# Expose lightweight tool wrappers
+from core.tools import adb, apktool, androguard
+__all__.extend(["adb", "apktool", "androguard"])

--- a/core/tools/__init__.py
+++ b/core/tools/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from . import adb, apktool, androguard
+
+__all__ = ["adb", "apktool", "androguard"]

--- a/core/tools/adb.py
+++ b/core/tools/adb.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import List
+
+from app_config import app_config
+
+
+def adb_path() -> str:
+    """Return the best ``adb`` path available on this system."""
+    path = app_config.get_adb_path()
+    which = shutil.which("adb")
+    try:
+        subprocess.run(
+            [path, "version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=True,
+        )
+        return path
+    except Exception:
+        return which or path
+
+
+def run(args: List[str], *, timeout: int = 8) -> subprocess.CompletedProcess:
+    """Run adb with robust defaults and return the completed process."""
+    cmd = [adb_path(), *args]
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - external dependency
+        raise RuntimeError("adb is not installed or not found in PATH") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(f"adb failed with code {exc.returncode}") from exc
+
+
+__all__ = ["run", "adb_path"]

--- a/core/tools/androguard.py
+++ b/core/tools/androguard.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Sequence
+
+
+def run(args: Sequence[str], *, timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run the ``androguard`` command with the given arguments."""
+    cmd = ["androguard", *args]
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - external dependency
+        raise RuntimeError("androguard is not installed or not found in PATH") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(f"androguard failed with code {exc.returncode}") from exc
+
+
+__all__ = ["run"]

--- a/core/tools/apktool.py
+++ b/core/tools/apktool.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Sequence
+
+
+def run(args: Sequence[str], *, timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run ``apktool`` with the provided arguments."""
+    cmd = ["apktool", *args]
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - external dependency
+        raise RuntimeError("apktool is not installed or not found in PATH") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(f"apktool failed with code {exc.returncode}") from exc
+
+
+__all__ = ["run"]

--- a/platform/android/analysis/static/adapters/apktool.py
+++ b/platform/android/analysis/static/adapters/apktool.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .common import run_tool
+from core.tools import apktool as _apktool
 
 
 def decompile(apk: Path, out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
-    run_tool(["apktool", "d", str(apk), "-o", str(out_dir)], "apktool")
+    _apktool.run(["d", str(apk), "-o", str(out_dir)])
     return out_dir
 
 __all__ = ["decompile"]

--- a/platform/android/devices/adb.py
+++ b/platform/android/devices/adb.py
@@ -4,27 +4,6 @@
 
 from __future__ import annotations
 
-import shutil
-import subprocess
-from app_config import app_config
+from core.tools.adb import adb_path as _adb_path, run as _run_adb
 
-
-def _run_adb(args: list[str], *, timeout: int = 8) -> subprocess.CompletedProcess:
-    """Run adb with robust defaults and return the completed process."""
-    return subprocess.run(args, capture_output=True, text=True, check=True, timeout=timeout)
-
-
-def _adb_path() -> str:
-    """Return the best ``adb`` path available on this system."""
-    path = app_config.get_adb_path()
-    which = shutil.which("adb")
-    try:
-        subprocess.run(
-            [path, "version"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=2,
-        )
-        return path
-    except Exception:
-        return which or path
+__all__ = ["_run_adb", "_adb_path"]


### PR DESCRIPTION
## Summary
- Add lightweight subprocess wrappers for adb, apktool, and androguard under `core.tools`
- Delegate device and static analysis helpers to the new wrappers
- Expose tool helpers via the analysis package for CLI access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6a4929ef883278c0137fda67c5498