### PR TITLE
fix: expose reporting helper and drop storage deps

### DIFF
--- a/cli/actions/analysis.py
+++ b/cli/actions/analysis.py
@@ -10,7 +10,6 @@ from devices import apk, packages
 from sandbox import compute_runtime_metrics
 from sandbox import run_analysis as sandbox_analyze
 from sandbox import ui_driver
-from storage.repository import AnalysisRepository
 from utils.display_utils import display
 from utils.reporting_utils import ieee
 
@@ -39,10 +38,8 @@ def analyze_apk_path() -> None:
             display.fail(f"Analysis failed: {e}")
             return
         report_path = out / "report.json"
-        try:
-            AnalysisRepository().upsert(app_name, str(report_path))
-        except Exception:
-            logger.exception("failed to record analysis")
+        # Database storage has been removed for the MVP, so the report path is
+        # not persisted.  Future iterations may reintroduce this functionality.
         logger.info("analysis completed", extra={"output": str(out)})
         print(f"Status: Static analysis completed. Report at {report_path}")
         _display_manifest_insights(out)
@@ -90,10 +87,8 @@ def analyze_installed_app(serial: str) -> None:
             return
 
         report_path = out / "report.json"
-        try:
-            AnalysisRepository().upsert(package, str(report_path))
-        except Exception:
-            logger.exception("failed to record analysis")
+        # Storage of analysis metadata is temporarily disabled in the CLI-only
+        # phase.
         logger.info("analysis completed", extra={"report": str(report_path)})
         print(f"Status: Static analysis completed. Report at {report_path}")
         _display_manifest_insights(out)
@@ -122,11 +117,7 @@ def sandbox_analyze_apk() -> None:
             return
 
         report_path = outdir / "metrics.json"
-        try:
-            target_path = report_path if report_path.exists() else outdir
-            AnalysisRepository().upsert(app_name, str(target_path))
-        except Exception:
-            logger.exception("failed to record analysis")
+        # Persistence is not available in the trimmed MVP.
 
         logger.info("sandbox analysis completed", extra={"output": str(outdir)})
         print(f"Status: Sandbox analysis completed. Results in {outdir}")

--- a/cli/actions/server.py
+++ b/cli/actions/server.py
@@ -4,66 +4,19 @@ import socket
 import threading
 import webbrowser
 
-from sqlalchemy import text
-
 from server.serve import serve
 from settings import get_settings
-from storage.repository import DATABASE_URL, ping_db, session_scope
 from utils.display_utils import display
 
 from .utils import action_context as _action_context
 from .utils import logger
 
 
-def _fetch_recent_analyses(conn, limit: int = 10) -> list[list[str | int | None]]:
-    """Return the most recent analyses records for display."""
-    try:
-        res = conn.execute(
-            text("SELECT package_name, score, status " "FROM analyses ORDER BY id DESC LIMIT :lim"),
-            {"lim": limit},
-        )
-        return [[row[0], row[1], row[2]] for row in res]
-    except Exception:
-        return []
-
-
-def _redact(url: str) -> str:
-    """Hide password in DSN when printing."""
-    if "://" not in url:
-        return url
-    scheme, rest = url.split("://", 1)
-    if "@" in rest and ":" in rest.split("@", 1)[0]:
-        creds, hostpart = rest.split("@", 1)
-        user = creds.split(":", 1)[0]
-        rest = f"{user}:***@{hostpart}"
-    return f"{scheme}://{rest}"
-
-
 def show_database_status() -> None:
-    """Report connectivity and basic statistics for the configured database."""
+    """Indicate that the persistent database layer is disabled."""
     logger.info("show_database_status")
-
     display.print_section("Database")
-    print(f"DSN: {_redact(DATABASE_URL)}")
-
-    ok, ver_or_err, ms = ping_db()
-    if ok:
-        display.ok(f"MySQL version: {ver_or_err} ({ms:.1f} ms)")
-    else:
-        display.warn(f"DB check failed in {ms:.1f} ms → {ver_or_err}")
-        return
-
-    try:
-        with session_scope() as s:
-            rows = _fetch_recent_analyses(s, limit=10)  # type: ignore[arg-type]
-    except Exception:
-        rows = []
-
-    display.print_section("Recent Analyses")
-    if rows:
-        display.print_table(rows, headers=["Package", "Score", "Status"])
-    else:
-        print("No analysis records found.")
+    print("Database functionality is currently disabled in the CLI-focused MVP.")
 
 
 def launch_web_app(host: str = get_settings().host, port: int = get_settings().port) -> None:

--- a/platform/android/analysis/static/__init__.py
+++ b/platform/android/analysis/static/__init__.py
@@ -1,12 +1,5 @@
-from . import adapters, diff, extractors, ml_model, pipeline, report, rules, yara_scan
+"""Minimal package for Android static analysis utilities."""
 
 __all__ = [
-    "adapters",
-    "diff",
-    "extractors",
-    "ml_model",
     "pipeline",
-    "report",
-    "rules",
-    "yara_scan",
 ]

--- a/utils/reporting_utils/__init__.py
+++ b/utils/reporting_utils/__init__.py
@@ -10,6 +10,7 @@ from .ieee import (
     major_heading,
     subsection_heading,
 )
+from .report_utils import generate_report
 
 __all__ = [
     "format_device_inventory",
@@ -20,4 +21,5 @@ __all__ = [
     "ieee_table",
     "major_heading",
     "subsection_heading",
+    "generate_report",
 ]

--- a/utils/reporting_utils/report_utils.py
+++ b/utils/reporting_utils/report_utils.py
@@ -10,5 +10,12 @@ def fetch_latest(*args, **kwargs):
     return None
 
 def generate_report(*args, **kwargs):
-    """Return a placeholder report string."""
-    return ""
+    """Return a placeholder risk report structure.
+
+    The full reporting subsystem has been stripped for the MVP, but callers
+    in the static analysis pipeline still expect a mapping of risk metrics.
+    Returning an empty ``dict`` keeps the interface intact without performing
+    any scoring logic.
+    """
+
+    return {}


### PR DESCRIPTION
## Summary
- expose `generate_report` in `utils.reporting_utils` and return empty dict
- simplify static analysis package init to avoid importing optional modules
- drop database persistence dependencies from CLI actions and stub server status

## Testing
- `python main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6a3bf220c832783e8bda3bbd0349c