### PR TITLE
Park dynamic sandbox feature

### DIFF
--- a/ANDROID_ANALYSIS_SETUP.md
+++ b/ANDROID_ANALYSIS_SETUP.md
@@ -45,6 +45,8 @@ Android applications using both static and dynamic techniques.
   runtime inspection before deeper analysis.
 
 ## 3. Dynamic Analysis (Optional)
+
+**Note:** The dynamic sandbox is deferred for the MVP. See [sandbox/PARKED.md](sandbox/PARKED.md); avoid relying on sandboxing until it resumes.
 - Use a dedicated device or emulator and install monitoring tools such as
   `mitmproxy` for network inspection and `logcat` for runtime logs.
 - Execute the target APK and monitor network requests, system calls, and

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ python -m cli.actions list-packages <device-serial>
 
 #### Sandbox analysis
 
+> **Note:** Dynamic sandboxing is deferred for the MVP. The sandbox code is parked; see [sandbox/PARKED.md](sandbox/PARKED.md). Avoid modifying or relying on this functionality.
+
 ```
 python main.py
 # Analysis → Sandbox APK → select /path/to/app.apk

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ The static pipeline under `platform/android/analysis/static/` decompiles APKs, e
 
 ## Dynamic Sandbox
 
+**Note:** The dynamic sandbox is parked for the MVP. See [sandbox/PARKED.md](../sandbox/PARKED.md). Avoid modifying or relying on this component until work resumes.
+
 Dynamic analysis lives in `platform/android/analysis/dynamic/`. The `runner.py` module simulates execution of an APK with Frida instrumentation hooks defined in `frida/`. Observed runtime events are converted into metrics that complement static findings.
 
 ## Risk Scoring

--- a/docs/dynamic-analysis.md
+++ b/docs/dynamic-analysis.md
@@ -1,5 +1,8 @@
 # Dynamic Analysis
 
+**Note:** The dynamic sandbox is parked for the MVP. See [sandbox/PARKED.md](../sandbox/PARKED.md) for details. Avoid modifying or relying on these modules.
+
+
 Rotterdam's dynamic analysis simulates running an APK inside a temporary sandbox and collects runtime behavior.
 
 ## Runner

--- a/sandbox/PARKED.md
+++ b/sandbox/PARKED.md
@@ -1,0 +1,4 @@
+# Sandbox on hold
+
+Dynamic sandboxing is deferred for the MVP. Code in this directory is parked and not maintained.
+Future work may revisit this, but for now avoid modifying or relying on these modules.


### PR DESCRIPTION
## Summary
- document that dynamic sandboxing is deferred via `sandbox/PARKED.md`
- reference parking notice in README and docs to steer contributors away from sandbox work

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6ad19f0e48327a957870567315c07