### PR TITLE
Fix partial path loading for UI partials

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from utils.logging_utils.app_logger import app_logger
@@ -27,7 +27,6 @@ REPO_ROOT = THIS_DIR.parent
 # root so that the mounts below can serve them correctly.
 UI_DIR = (REPO_ROOT / "ui").resolve()
 INDEX_HTML = UI_DIR / "pages" / "index.html"
-FAVICON_ICO = UI_DIR / "favicon.ico"
 
 
 def _mask_path(p: Path) -> str:
@@ -110,7 +109,6 @@ async def _startup_checks() -> None:
     log.info("ROOT_PATH=%s", ROOT_PATH or "(none)")
     log.info("UI_DIR=%s exists=%s", UI_DIR, UI_DIR.exists())
     log.info("INDEX_HTML=%s exists=%s", INDEX_HTML, INDEX_HTML.exists())
-    log.info("FAVICON_ICO=%s exists=%s", FAVICON_ICO, FAVICON_ICO.exists())
     if not UI_DIR.exists():
         log.warning("UI directory missing — static mounts will 404: %s", UI_DIR)
     if not INDEX_HTML.exists():
@@ -139,10 +137,6 @@ async def diag() -> JSONResponse:
                 "path": _mask_path(INDEX_HTML),
                 "exists": INDEX_HTML.exists(),
             },
-            "favicon_ico": {
-                "path": _mask_path(FAVICON_ICO),
-                "exists": FAVICON_ICO.exists(),
-            },
         }
     )
 
@@ -156,10 +150,3 @@ async def root() -> FileResponse:
     masked = _mask_path(INDEX_HTML)
     raise HTTPException(status_code=500, detail=f"index not found at {masked}")
 
-
-# Favicon (no union return annotation)
-@app.get("/favicon.ico", include_in_schema=False)
-async def favicon():
-    if FAVICON_ICO.exists():
-        return FileResponse(str(FAVICON_ICO))
-    return PlainTextResponse("favicon not found", status_code=404)

--- a/server/middleware/settings.py
+++ b/server/middleware/settings.py
@@ -64,7 +64,6 @@ class Settings:
         trust_proxy = _env_bool("TRUST_PROXY", False)
         public_paths = {
             "/",
-            "/favicon.ico",
             "/_healthz",
             "/_ready",
             "/ui",

--- a/ui/js/helpers.js
+++ b/ui/js/helpers.js
@@ -1,9 +1,9 @@
 const BASE_PATH = '/ui';
 
 $(function () {
-  $('#header').load(`${BASE_PATH}/ui/partials/header.html`);
-  $('#footer').load(`${BASE_PATH}/ui/partials/footer.html`);
-  $('#sidebar').load(`${BASE_PATH}/ui/partials/sidebar.html`, function () {
+  $('#header').load(`${BASE_PATH}/partials/header.html`);
+  $('#footer').load(`${BASE_PATH}/partials/footer.html`);
+  $('#sidebar').load(`${BASE_PATH}/partials/sidebar.html`, function () {
     const page = window.location.pathname.split('/').pop();
     $(`#sidebar a[href='${page}']`).addClass('active');
   });


### PR DESCRIPTION
## Summary
- remove duplicate `/ui` path segment when loading header, footer, and sidebar partials
- remove default favicon and references across server and HTML pages

## Testing
- `pytest`
- `python -m uvicorn server.main:app --host 127.0.0.1 --port 8000 &`
- `curl -I http://127.0.0.1:8000/ui/partials/header.html`
- `curl -I http://127.0.0.1:8000/ui/favicon.ico`

------
https://chatgpt.com/codex/tasks/task_e_68a6ad1aa0448327977cdeb669503723