### PR TITLE
Fix partial URLs for UI partials

### DIFF
--- a/ui/js/helpers.js
+++ b/ui/js/helpers.js
@@ -1,9 +1,9 @@
 const BASE_PATH = '/ui';
 
 $(function () {
-  $('#header').load(`${BASE_PATH}/ui/partials/header.html`);
-  $('#footer').load(`${BASE_PATH}/ui/partials/footer.html`);
-  $('#sidebar').load(`${BASE_PATH}/ui/partials/sidebar.html`, function () {
+  $('#header').load(`${BASE_PATH}/partials/header.html`);
+  $('#footer').load(`${BASE_PATH}/partials/footer.html`);
+  $('#sidebar').load(`${BASE_PATH}/partials/sidebar.html`, function () {
     const page = window.location.pathname.split('/').pop();
     $(`#sidebar a[href='${page}']`).addClass('active');
   });


### PR DESCRIPTION
## Summary
- fix helper URLs to load partials from `/ui/partials`

## Testing
- `pre-commit run --files ui/js/helpers.js`
- `pytest`
- `python -m http.server 8000` then `curl -I http://localhost:8000/ui/partials/header.html`

------
https://chatgpt.com/codex/tasks/task_e_68a6b34950648327ba23fe435216296b