### PR TITLE
feat: make API key configurable for UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ export ROTTERDAM_API_KEY="my-strong-key"  # default "secret" will trigger a warn
 python -m cli.actions serve
 ```
 
+The browser UI sends this key on all requests. Expose it to the page with a
+`<meta>` tag or by pointing to an endpoint that returns the key:
+
+```html
+<meta name="api-key" content="my-strong-key" />
+<!-- or -->
+<meta name="api-key-endpoint" content="/path/to/key" />
+```
+`ui/js/helpers.js` reads one of these tags and sets the `X-API-Key` header
+accordingly.
+
 Using the default API key `secret` is only suitable for local testing and will
 log a warning on startup. The server starts on `localhost:8765` by default and
 exposes endpoints:

--- a/run.sh
+++ b/run.sh
@@ -60,6 +60,7 @@ Options:
 Notes:
 - This script assumes ./setup.sh has already been run.
 - The web server is typically started from inside the CLI menu.
+- Set ROTTERDAM_API_KEY to configure API authentication.
 EOF
 }
 
@@ -106,10 +107,12 @@ export PYTHONPATH="$ROOT_DIR:${PYTHONPATH:-}"
 export APP_HOST="$APP_HOST"
 export APP_PORT="$APP_PORT"
 export PORT="$APP_PORT"
+export ROTTERDAM_API_KEY="${ROTTERDAM_API_KEY:-secret}"
 
 note "Environment:"
 note "  APP_HOST=${APP_HOST}"
 note "  APP_PORT=${APP_PORT}"
+note "  ROTTERDAM_API_KEY=${ROTTERDAM_API_KEY:-secret}"
 good "Launching Rotterdam menu (python main.py)..."
 
 exec python main.py "${CLI_ARGS[@]}"

--- a/ui/js/helpers.js
+++ b/ui/js/helpers.js
@@ -9,7 +9,28 @@ $(function () {
   });
 });
 
-window.API_HEADERS = { 'X-API-Key': 'secret' };
+function resolveApiKey() {
+  const metaKey = document.querySelector("meta[name='api-key']");
+  if (metaKey && metaKey.content) {
+    return metaKey.content;
+  }
+  const metaEndpoint = document.querySelector("meta[name='api-key-endpoint']");
+  if (metaEndpoint && metaEndpoint.content) {
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', metaEndpoint.content, false);
+      xhr.send(null);
+      if (xhr.status === 200 && xhr.responseText.trim()) {
+        return xhr.responseText.trim();
+      }
+    } catch (err) {
+      console.error('Failed to fetch API key', err);
+    }
+  }
+  return 'secret';
+}
+
+window.API_HEADERS = { 'X-API-Key': resolveApiKey() };
 
 window.api = {
   get: (path) =>


### PR DESCRIPTION
## Summary
- read API key for AJAX requests from `<meta>` tag or endpoint
- surface `ROTTERDAM_API_KEY` usage in run script and docs

## Testing
- `pre-commit run --files ui/js/helpers.js run.sh README.md`
- `pytest`
- `node` sample scripts verifying API key resolution

------
https://chatgpt.com/codex/tasks/task_e_68a6b350d2088327808a4b609035ca9e