### PR TITLE
Strip favicon support until branding phase

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,3 @@
 # Developing Rotterdam
 
-The repository does not track a favicon. To use one locally, place a `favicon.ico`
-file under `ui/` (e.g., `ui/favicon.ico`). Git ignores `.ico` files, so your
-icon will remain local.
+Developer documentation will be added here in the future.

--- a/server/main.py
+++ b/server/main.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from utils.logging_utils.app_logger import app_logger
@@ -27,7 +27,6 @@ REPO_ROOT = THIS_DIR.parent
 # root so that the mounts below can serve them correctly.
 UI_DIR = (REPO_ROOT / "ui").resolve()
 INDEX_HTML = UI_DIR / "pages" / "index.html"
-FAVICON_ICO = UI_DIR / "favicon.ico"
 
 
 def _mask_path(p: Path) -> str:
@@ -84,15 +83,6 @@ app.include_router(reports_router)
 app.include_router(analytics_router)
 app.include_router(system_router)  # owns /_healthz (and /_ready if present)
 
-# ---------- Favicon ----------
-async def _favicon() -> Response:
-    if FAVICON_ICO.exists():
-        return FileResponse(str(FAVICON_ICO))
-    return Response(status_code=204)
-
-app.add_api_route("/favicon.ico", _favicon, include_in_schema=False)
-app.add_api_route("/ui/favicon.ico", _favicon, include_in_schema=False)
-
 # ---------- Static mounts ----------
 # Serve entire ui/ under both /ui and /static for compatibility.
 # Use check_dir=False so startup won't crash if UI_DIR is missing (we log warnings).
@@ -119,7 +109,6 @@ async def _startup_checks() -> None:
     log.info("ROOT_PATH=%s", ROOT_PATH or "(none)")
     log.info("UI_DIR=%s exists=%s", UI_DIR, UI_DIR.exists())
     log.info("INDEX_HTML=%s exists=%s", INDEX_HTML, INDEX_HTML.exists())
-    log.info("FAVICON_ICO=%s exists=%s", FAVICON_ICO, FAVICON_ICO.exists())
     if not UI_DIR.exists():
         log.warning("UI directory missing — static mounts will 404: %s", UI_DIR)
     if not INDEX_HTML.exists():
@@ -147,10 +136,6 @@ async def diag() -> JSONResponse:
             "index_html": {
                 "path": _mask_path(INDEX_HTML),
                 "exists": INDEX_HTML.exists(),
-            },
-            "favicon_ico": {
-                "path": _mask_path(FAVICON_ICO),
-                "exists": FAVICON_ICO.exists(),
             },
         }
     )

--- a/server/middleware/settings.py
+++ b/server/middleware/settings.py
@@ -64,7 +64,6 @@ class Settings:
         trust_proxy = _env_bool("TRUST_PROXY", False)
         public_paths = {
             "/",
-            "/favicon.ico",
             "/_healthz",
             "/_ready",
             "/ui",

--- a/ui/favicon.ico.placeholder
+++ b/ui/favicon.ico.placeholder
@@ -1,1 +1,0 @@
-Place custom favicon.ico here. This file is ignored.

--- a/ui/pages/analytics.html
+++ b/ui/pages/analytics.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Analytics - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/analyze.html
+++ b/ui/pages/analyze.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Analyze - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/current-device.html
+++ b/ui/pages/current-device.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Current Device - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/device-stats.html
+++ b/ui/pages/device-stats.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Device Stats - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/devices.html
+++ b/ui/pages/devices.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Devices - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/index.html
+++ b/ui/pages/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Rotterdam Dashboard</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/jobs.html
+++ b/ui/pages/jobs.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Jobs - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/report-detail.html
+++ b/ui/pages/report-detail.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Report Detail - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/ui/pages/reports.html
+++ b/ui/pages/reports.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Reports - Rotterdam</title>
-    <link rel="icon" href="/ui/favicon.ico" />
     <link rel="stylesheet" href="/ui/css/styles.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>


### PR DESCRIPTION
## Summary
- remove server-side favicon routes and startup checks
- drop `/favicon.ico` from public-path settings

## Testing
- `pytest`
- `uvicorn server.main:app --port 8000` *(fails: ModuleNotFoundError: No module named 'platform.android')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b34c10648327960e107bf2077098