### PR TITLE
feat: categorize and score installed apps

### DIFF
--- a/cli/actions/device.py
+++ b/cli/actions/device.py
@@ -138,6 +138,8 @@ def list_installed_packages(
                 "yes" if p.get("system") else "no",
                 "yes" if p.get("priv") else "no",
                 "yes" if p.get("high_value") else "no",
+                ", ".join(p.get("categories", [])),
+                p.get("risk_score", 0),
             ]
             for p in pkg_info
         ]
@@ -151,8 +153,15 @@ def list_installed_packages(
                 "System",
                 "Priv",
                 "High-Value",
+                "Categories",
+                "Risk",
             ],
         )
+
+        total = len(pkg_info)
+        flagged = sum(1 for p in pkg_info if p.get("risk_score", 0) > 0)
+        display.note(f"Total packages: {total}")
+        display.note(f"Flagged packages: {flagged}")
 
         if csv_path:
             try:
@@ -167,6 +176,9 @@ def list_installed_packages(
                             "system",
                             "priv",
                             "high_value",
+                            "categories",
+                            "risk_score",
+                            "dangerous_permissions",
                         ],
                     )
                     writer.writeheader()
@@ -198,8 +210,16 @@ def scan_dangerous_permissions(serial: str) -> None:
             logger.info("no apps with dangerous permissions")
             print("No apps requesting dangerous permissions found.")
             return
-        rows = [[r.get("package", ""), ", ".join(r.get("permissions", []))] for r in risky]
-        display.print_table(rows, headers=["Package", "Permissions"])
+        rows = [
+            [
+                r.get("package", ""),
+                ", ".join(r.get("permissions", [])),
+                ", ".join(r.get("categories", [])),
+                r.get("risk_score", 0),
+            ]
+            for r in risky
+        ]
+        display.print_table(rows, headers=["Package", "Permissions", "Categories", "Risk"])
 
 
 def scan_for_devices() -> None:

--- a/platform/android/devices/packages.py
+++ b/platform/android/devices/packages.py
@@ -5,12 +5,12 @@
 from __future__ import annotations
 
 import subprocess
-from typing import List, Dict, Any
+from typing import Any, Dict, List, Set
 
 from .adb import _run_adb
 
 # A small, non-exhaustive set of permissions considered risky for demos.
-DANGEROUS_PERMISSIONS = {
+DANGEROUS_PERMISSIONS: Set[str] = {
     "android.permission.READ_SMS",
     "android.permission.RECEIVE_SMS",
     "android.permission.SEND_SMS",
@@ -24,14 +24,36 @@ DANGEROUS_PERMISSIONS = {
 }
 
 # Common social media or high-value packages to flag during inventory
-HIGH_VALUE_PACKAGES = {
+HIGH_VALUE_PACKAGES: Set[str] = {
     "com.twitter.android",
     "com.instagram.android",
     "com.facebook.katana",
     "com.facebook.orca",
     "com.whatsapp",
     "com.zhiliaoapp.musically",  # TikTok
-    "com.ss.android.ugc.trill",   # TikTok alt package name
+    "com.ss.android.ugc.trill",  # TikTok alt package name
+}
+
+# Hardcoded mapping of known packages to categories.  These lists are intentionally
+# small and primarily serve as examples for how categorisation could work.  The
+# structure makes it easy to later replace with a JSON or database driven
+# configuration.
+APP_CATEGORIES: Dict[str, Set[str]] = {
+    "Social Media": {
+        "com.twitter.android",
+        "com.instagram.android",
+        "com.facebook.katana",
+        "com.zhiliaoapp.musically",
+        "com.ss.android.ugc.trill",
+    },
+    "Messaging": {
+        "com.whatsapp",
+        "com.facebook.orca",
+    },
+    "Financial": {
+        "com.paypal.android.p2pmobile",
+        "com.chase.sig.android",
+    },
 }
 
 
@@ -67,15 +89,38 @@ def _get_permissions(serial: str, package: str) -> List[str]:
     return perms
 
 
-def scan_for_dangerous_permissions(serial: str) -> List[Dict[str, List[str]]]:
-    """Return packages that request permissions in DANGEROUS_PERMISSIONS."""
-    results: List[Dict[str, List[str]]] = []
+def _categorize_package(pkg: str) -> List[str]:
+    """Return a list of categories that the package is known to belong to."""
+    cats: List[str] = []
+    for category, names in APP_CATEGORIES.items():
+        if pkg in names:
+            cats.append(category)
+    return cats
+
+
+def scan_for_dangerous_permissions(serial: str) -> List[Dict[str, Any]]:
+    """Return packages that request permissions in ``DANGEROUS_PERMISSIONS``.
+
+    Each result includes the package name, matched permissions, categories and a
+    naive risk score based on the number of dangerous permissions requested.
+    """
+
+    results: List[Dict[str, Any]] = []
     packages = list_installed_packages(serial)
     for pkg in packages:
         perms = _get_permissions(serial, pkg)
         risky = sorted(p for p in perms if p in DANGEROUS_PERMISSIONS)
         if risky:
-            results.append({"package": pkg, "permissions": risky})
+            categories = _categorize_package(pkg)
+            risk = len(risky) + (1 if pkg in HIGH_VALUE_PACKAGES else 0)
+            results.append(
+                {
+                    "package": pkg,
+                    "permissions": risky,
+                    "risk_score": risk,
+                    "categories": categories,
+                }
+            )
     return results
 
 
@@ -117,7 +162,7 @@ def inventory_packages(serial: str) -> List[Dict[str, Any]]:
             pkg = pkg_part
         system_app = bool(path) and not path.startswith("/data/")
         priv_app = "/priv-app/" in path
-        info: Dict[str, str] = {
+        info: Dict[str, Any] = {
             "package": pkg,
             "path": path,
             "installer": installer,
@@ -127,13 +172,14 @@ def inventory_packages(serial: str) -> List[Dict[str, Any]]:
             "uid": "",
             "system": system_app,
             "priv": priv_app,
+            "dangerous_permissions": [],
+            "risk_score": 0,
+            "categories": _categorize_package(pkg),
         }
 
         # Fetch version details and additional metadata
         try:
-            dump = _run_adb(
-                [adb, "-s", serial, "shell", "dumpsys", "package", pkg], timeout=10
-            )
+            dump = _run_adb(["-s", serial, "shell", "dumpsys", "package", pkg], timeout=10)
             for ln in (dump.stdout or "").splitlines():
                 ln = ln.strip()
                 if ln.startswith("versionName="):
@@ -148,6 +194,16 @@ def inventory_packages(serial: str) -> List[Dict[str, Any]]:
                         info["system"] = True
                     if "PRIVILEGED" in flags:
                         info["priv"] = True
+                elif ln.startswith("uses-permission:"):
+                    perm = ln.split(":", 1)[1].strip()
+                    if perm:
+                        info.setdefault("permissions", []).append(perm)
+                        if perm in DANGEROUS_PERMISSIONS:
+                            info["dangerous_permissions"].append(perm)
+            # Calculate risk score once permissions gathered
+            info["risk_score"] = len(info["dangerous_permissions"]) + (
+                1 if info["high_value"] else 0
+            )
         except subprocess.CalledProcessError:
             pass
 

--- a/run_dynamic_analysis.py
+++ b/run_dynamic_analysis.py
@@ -1,0 +1,17 @@
+"""Placeholder entry point for future dynamic analysis pipeline.
+
+This script currently serves as a stub while dynamic analysis is
+deferrred for later development phases. Invoking it will simply emit a
+warning to the logs indicating the feature is not yet implemented.
+"""
+
+from utils.logging_utils.log_helpers import LoggingHelper
+
+
+def main() -> None:
+    """Entry point for dynamic analysis stub."""
+    LoggingHelper.warning("Dynamic analysis is not implemented yet. This is a placeholder script.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,46 @@
+import subprocess
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.modules.pop("platform", None)
+
+from platform.android.devices import packages
+
+
+def test_inventory_packages_categorises_and_scores(monkeypatch):
+    list_output = (
+        "package:/data/app/com.whatsapp/base.apk=com.whatsapp installer=com.android.vending\n"
+    )
+    dumpsys_output = (
+        "package: com.whatsapp\n"
+        "versionName=2.0\n"
+        "versionCode=200\n"
+        "uid=1000\n"
+        "uses-permission:android.permission.RECORD_AUDIO\n"
+        "uses-permission:android.permission.READ_SMS\n"
+    )
+
+    def fake_run(args, timeout=10):
+        cmd = " ".join(args)
+        if "pm list packages" in cmd:
+            return subprocess.CompletedProcess(args, 0, stdout=list_output, stderr="")
+        if "dumpsys package com.whatsapp" in cmd:
+            return subprocess.CompletedProcess(args, 0, stdout=dumpsys_output, stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(packages, "_run_adb", fake_run)
+
+    result = packages.inventory_packages("serial123")
+    assert result
+    app = result[0]
+    assert app["package"] == "com.whatsapp"
+    # Categorised as Messaging and assigned risk score (2 perms + high value)
+    assert "Messaging" in app["categories"]
+    assert app["risk_score"] == 3
+    assert sorted(app["dangerous_permissions"]) == [
+        "android.permission.READ_SMS",
+        "android.permission.RECORD_AUDIO",
+    ]

--- a/utils/logging_utils/__init__.py
+++ b/utils/logging_utils/__init__.py
@@ -1,5 +1,13 @@
 """Structured logging helpers."""
 
+from .app_logger import app_logger
+from .log_helpers import LoggingHelper
 from .logging_config import StructuredLogger, get_logger, log_context
 
-__all__ = ["StructuredLogger", "get_logger", "log_context"]
+__all__ = [
+    "StructuredLogger",
+    "get_logger",
+    "log_context",
+    "LoggingHelper",
+    "app_logger",
+]

--- a/utils/logging_utils/log_helpers.py
+++ b/utils/logging_utils/log_helpers.py
@@ -14,6 +14,11 @@ class LoggingHelper:
     """Convenience helpers for emitting log messages through ``app_logger``."""
 
     @staticmethod
+    def debug(message: str, *, logger_name: str | None = None) -> None:
+        """Log a debug message."""
+        app_logger.get_logger(logger_name).debug(message)
+
+    @staticmethod
     def info(message: str, *, logger_name: str | None = None) -> None:
         """Log an informational message."""
         app_logger.get_logger(logger_name).info(message)
@@ -31,4 +36,8 @@ class LoggingHelper:
         exc: Exception | None = None,
     ) -> None:
         """Log an error message and optional exception information."""
-        app_logger.get_logger(logger_name).error(message, exc_info=exc)
+        logger = app_logger.get_logger(logger_name)
+        if exc is not None:
+            logger.exception(message, exc_info=exc)
+        else:
+            logger.error(message)


### PR DESCRIPTION
## Summary
- catalog known app categories and high-value packages
- compute simple risk scores from dangerous permissions
- display categories and risk metrics in package listings
- test package inventory categorization
- expose logging helpers and support debug/error exception logging
- add placeholder script for future dynamic analysis

## Testing
- `pre-commit run --files run_dynamic_analysis.py utils/logging_utils/log_helpers.py utils/logging_utils/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a772c2a05c83279e2a1bc0c8a921c6